### PR TITLE
Add config option to audit console or not. Fix for route bug if in console

### DIFF
--- a/config/auditing.php
+++ b/config/auditing.php
@@ -44,4 +44,15 @@ return [
     */
 
     'table' => 'logs',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Audit console
+    |--------------------------------------------------------------------------
+    |
+    | Whether we should audit queries run through console (eg. php artisan db:seed).
+    |
+    */
+
+    'audit_console' => false,
 ];


### PR DESCRIPTION
Added some fixes for issue #49 .

Adds config option for logging console (eg. artisan db:seed) and also adds fix to return "console" as route when needed.