### PR TITLE
[3.1] Queue Auditable Models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,11 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.3.*",
+        "illuminate/bus": "5.3.*",
+        "illuminate/contracts": "5.3.*",
         "illuminate/database": "5.3.*",
+        "illuminate/queue": "5.3.*",
+        "illuminate/support": "5.3.*",
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {

--- a/config/auditing.php
+++ b/config/auditing.php
@@ -36,6 +36,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Queue Auditable Models
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control if the operations that audit your models
+    | with your auditors are queued. When this is set to "true" then all models 
+    | auditable will get queued for better performance.
+    |
+    */
+
+    'queue' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Table
     |--------------------------------------------------------------------------
     |

--- a/src/AuditQueuedModels.php
+++ b/src/AuditQueuedModels.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OwenIt\Auditing;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class AuditQueuedModels implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @var
+     */
+    private $auditable;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param mixed $auditable
+     *
+     * @return void
+     */
+    public function __construct($auditable)
+    {
+        $this->auditable = $auditable;
+    }
+
+    /**
+     * Audit the model auditable.
+     *
+     * @param \OwenIt\Auditing\AuditorManager $manager
+     *
+     * @return void
+     */
+    public function handle(AuditorManager $manager)
+    {
+        $manager->audit($this->auditable);
+    }
+}

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -8,13 +8,13 @@ use OwenIt\Auditing\Contracts\Dispatcher;
 trait Auditor
 {
     /**
-     * Audit the given information.
+     * Audit the model auditable.
      *
      * @return void
      */
     public function audit()
     {
-        app(Dispatcher::class)->audit($this);
+        app(Dispatcher::class)->makeAudit($this);
     }
 
     /**

--- a/src/Auditors/DatabaseAuditor.php
+++ b/src/Auditors/DatabaseAuditor.php
@@ -7,7 +7,7 @@ use OwenIt\Auditing\Auditing;
 class DatabaseAuditor
 {
     /**
-     * Audit the given model.
+     * Audit the model auditable.
      *
      * @param mixed $auditable
      *

--- a/src/Console/stubs/auditor.stub
+++ b/src/Console/stubs/auditor.stub
@@ -18,12 +18,12 @@ class DummyClass implements AuditContract
     }
 
     /**
-     * Audit the given information.
+     * Audit the model auditable.
      * 
-     * @param $auditable
+     * @param mixed $auditable
      * @return mixed
      */
-    public function audit($auditing)
+    public function audit($auditable)
     {
         //
     }

--- a/tests/AuditingQueuedAuditTest.php
+++ b/tests/AuditingQueuedAuditTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use OwenIt\Auditing\AuditQueuedModels;
+
+class AuditingQueuedAuditTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testQueueAudit()
+    {
+        $job = new AuditQueuedModels('auditable');
+
+        $manager = Mockery::mock('OwenIt\Auditing\AuditorManager');
+        $manager->shouldReceive('audit')->once()->with('auditable');
+
+        $job->handle($manager);
+    }
+}


### PR DESCRIPTION
This option allows you to control if the operations that audit your models with your auditors are queued. When this is set to "true" then all models  auditable will get queued for better performance.

```php
// config/auditing.php

'queue' => true,
```

Suggested by @Cannonb4ll  https://github.com/owen-it/laravel-auditing/issues/77