### PR TITLE
Fix double audits when saving two times in same session

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -131,6 +131,7 @@ trait Auditable
         if ($this->isTypeAuditable('created')) {
             $this->typeAuditing = 'created';
 
+            $this->newData = [];
             foreach ($this->updatedData as $key => $value) {
                 if ($this->isAuditing($key)) {
                     $this->newData[$key] = $value;
@@ -158,6 +159,8 @@ trait Auditable
                 return;
             }
 
+            $this->oldData = [];
+            $this->newData = [];
             foreach ($changesToTecord as $key => $change) {
                 $this->oldData[$key] = array_get($this->originalData, $key);
 


### PR DESCRIPTION
When you save a single model instance two times in the same session, then the second audit will also contain all the changes that have already been reflected in the first audit.

Example: Assume there is a user John Doe. Now we do:
```php
$u->firstname = 'Richard';
$u->save();
$u->lastname = 'Roe';
$u->save();
```
This generates two audits:
````php
{
    old: '{"firstname":"John"}',
    new: '{"firstname":"Richard"}'
}, {
    old: '{"firstname":"John","lastname":"Doe"}',
    new: '{"firstname":"Richard","lastname":"Roe"}'
}
````

This pull request ensures that the second audit only contains:
````php
{
    old: '{"lastname":"Doe"}',
    new: '{"lastname":"Roe"}'
}
````

Note that the [`syncOriginal()` function in `Illuminate\Database\Eloquent\Model`](https://github.com/laravel/framework/blob/v5.3.18/src/Illuminate/Database/Eloquent/Model.php#L3114) already does the trick, we only need to clean up our own data between runs.