### PR TITLE
[3.2] Added auditing many to many relationships for eloquent models

### DIFF
--- a/src/AuditObserver.php
+++ b/src/AuditObserver.php
@@ -52,4 +52,46 @@ class AuditObserver
         $model->prepareAudit();
         $model->auditDeletion();
     }
+
+    /**
+     * Handle when a model is attached to a relation
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param array $relationParams
+     *
+     * @return void
+     */
+    public function attached($model, array $relationParams)
+    {
+        $model->prepareGeneralAuditData();
+        $model->auditAttachedRelation($relationParams);
+    }
+
+    /**
+     * Handle the when a model relation is updated
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param array $relationParams
+     *
+     * @return void
+     */
+    public function updatedRelation($model, array $relationParams)
+    {
+        $model->prepareGeneralAuditData();
+        $model->auditUpdatedRelation($relationParams);
+    }
+
+    /**
+     * Handle when a model is detached drom a relation
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param array $relationParams
+     *
+     * @return void
+     */
+    public function detached($model, array $relationParams)
+    {
+        $model->prepareGeneralAuditData();
+        $model->auditDetachedRelation($relationParams);
+    }
 }

--- a/src/Console/stubs/audits.stub
+++ b/src/Console/stubs/audits.stub
@@ -16,12 +16,16 @@ class CreateAuditsTable extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('auditable');
+            $table->unsignedInteger('related_id')->nullable();
+            $table->string('related_type')->nullable();
             $table->text('old')->nullable();
             $table->text('new')->nullable();
             $table->string('user_id')->nullable();
             $table->string('route')->nullable();
             $table->ipAddress('ip_address', 45)->nullable();
             $table->timestamp('created_at');
+
+            $table->index(["related_id", "related_type"]);
         });
     }
 

--- a/src/CustomAuditMessage.php
+++ b/src/CustomAuditMessage.php
@@ -207,7 +207,7 @@ trait CustomAuditMessage
     {
         // Get the related type, it's guestimation so if this isn't providing what you want simply override this function
         if (in_array($this->type, ['attached', 'updatedRelation', 'detached'])) {
-            $relatedType = strtolower(substr($this->related_type, strrpos($this->related_type, '\\') + 1));
+            $relatedType = strtolower(str_replace('\\', '', substr($this->related_type, strrpos($this->related_type, '\\'))));
 
             switch ($this->type) {
                 case 'attached':

--- a/src/CustomAuditMessage.php
+++ b/src/CustomAuditMessage.php
@@ -197,4 +197,31 @@ trait CustomAuditMessage
 
         return parent::getTable();
     }
+
+    /**
+     * Get the audited type for in custom messages
+     *
+     * @return string
+     */
+    public function getAuditedTypeAttribute()
+    {
+        // Get the related type, it's guestimation so if this isn't providing what you want simply override this function
+        if (in_array($this->type, ['attached', 'updatedRelation', 'detached'])) {
+            $relatedType = strtolower(substr($this->related_type, strrpos($this->related_type, '\\') + 1));
+
+            switch ($this->type) {
+                case 'attached':
+                    return "attached a {$relatedType} to";
+                    break;
+                case 'updatedRelation':
+                    return "updated a related {$relatedType} attached to";
+                    break;
+                case 'detached':
+                    return "detached a {$relatedType} from";
+                    break;
+            }
+        }
+
+        return $this->type;
+    }
 }

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -1,0 +1,145 @@
+<?php
+namespace OwenIt\Auditing\Relations;
+
+/**
+ * Class BelongsToManyDecorator
+ * Stole most everything form here: https://github.com/laravel/framework/pull/14988
+ *
+ * @package OwenIt\Auditing\Relations
+ */
+class BelongsToMany extends \Illuminate\Database\Eloquent\Relations\BelongsToMany
+{
+    /**
+     * Attach a model to the parent.
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @param  bool   $touch
+     * @return void
+     */
+    public function attach($id, array $attributes = [], $touch = true)
+    {
+        // Attach the records
+        parent::attach($id, $attributes, $touch);
+
+        // Get the attached records
+        if ($id instanceof Model) {
+            $id = $id->getKey();
+        }
+
+        if ($id instanceof Collection) {
+            $id = $id->modelKeys();
+        }
+
+        $records = $this->createAttachRecords((array) $id, $attributes);
+
+        // Notify the parent model
+        foreach ($records as $record) {
+            $this->fireParentEvent(
+                'attached',
+                [
+                    'relationId' => $record[$this->otherKey],
+                    'relationName' => $this->relationName,
+                    'newData' => $record
+                ],
+                false
+            );
+        }
+    }
+
+    /**
+     * Update an existing pivot record on the table.
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @param  bool   $touch
+     * @return int
+     */
+    public function updateExistingPivot($id, array $attributes, $touch = true)
+    {
+        // Remember the current data
+        $oldData = $this->newPivotStatementForId($id)
+            ->select(array_keys($attributes))
+            ->first();
+
+        // Update the pivot
+        $updated =  parent::updateExistingPivot($id, $attributes, $touch);
+
+        // Notify the parent model
+        if ($updated > 0) {
+            $this->fireParentEvent(
+                'updatedRelation',
+                [
+                    'relationId' => $id,
+                    'relationName' => $this->relationName,
+                    'oldData' => (array) $oldData,
+                    'newData' => $attributes
+                ],
+                false
+            );
+        }
+
+        return $updated;
+    }
+
+    /**
+     * Detach models from the relationship.
+     *
+     * @param  mixed  $ids
+     * @param  bool  $touch
+     * @return int
+     */
+    public function detach($ids = [], $touch = true)
+    {
+        // Get the detachable items
+        if ($ids instanceof Model) {
+            $ids = $ids->getKey();
+        }
+
+        if ($ids instanceof Collection) {
+            $ids = $ids->modelKeys();
+        }
+
+        $records = ($this->getRelated()->find((array)$ids));
+
+        // Detach the related items
+        parent::detach($ids, $touch);
+
+        // Notify the parent model
+        foreach ($records as $record) {
+            $this->fireParentEvent(
+                'detached',
+                [
+                    'relationId' => $record[$this->getRelated()->getKeyName()],
+                    'relationName' => $this->relationName,
+                    'oldData' => $record->toArray()
+                ],
+                false
+            );
+        }
+    }
+
+    /**
+     * Fire the given event for the parent model.
+     *
+     * @param  string $event
+     * @param array $records
+     * @param  bool $halt
+     * @return mixed
+     */
+    protected function fireParentEvent($event, $records, $halt = true)
+    {
+        $dispatcher = $this->getParent()->getEventDispatcher();
+
+        if (!$dispatcher) {
+            return true;
+        }
+
+        $event = "eloquent.{$event}: ".get_class($this->getParent());
+
+        $method = $halt ? 'until' : 'fire';
+
+        return $dispatcher->$method($event, [$this->getParent(), $records]);
+    }
+
+}

--- a/tests/AuditObserverTest.php
+++ b/tests/AuditObserverTest.php
@@ -39,4 +39,31 @@ class AuditObserverTest extends AbstractTestCase
         $model->shouldReceive('auditDeletion');
         $observer->deleted($model);
     }
+
+    public function test_attached_handler_audit_attach_relation()
+    {
+        $observer = new AuditObserver();
+        $model = Mockery::mock();
+        $model->shouldReceive('prepareGeneralAuditData');
+        $model->shouldReceive('auditUpdatedRelation');
+        $observer->updatedRelation($model, []);
+    }
+
+    public function test_saved_handler_audit_updated_relation()
+    {
+        $observer = new AuditObserver();
+        $model = Mockery::mock();
+        $model->shouldReceive('prepareGeneralAuditData');
+        $model->shouldReceive('auditUpdatedRelation');
+        $observer->updatedRelation($model, []);
+    }
+
+    public function test_detached_handler_audit_detach_relation()
+    {
+        $observer = new AuditObserver();
+        $model = Mockery::mock();
+        $model->shouldReceive('prepareGeneralAuditData');
+        $model->shouldReceive('auditDetachedRelation');
+        $observer->detached($model, []);
+    }
 }

--- a/tests/AuditableTest.php
+++ b/tests/AuditableTest.php
@@ -48,6 +48,7 @@ class AuditableTest extends AbstractTestCase
         $types = [
                 'created', 'updated', 'deleted',
                 'saved', 'restored',
+                'attached', 'updatedRelation', 'detached'
         ];
 
         $this->assertEquals($types, $model1->getAuditableTypes());

--- a/tests/AuditingTest.php
+++ b/tests/AuditingTest.php
@@ -24,6 +24,26 @@ class AuditingTest extends AbstractTestCase
         $this->assertEquals('The title was defined as awesome.', $callbackMethod);
     }
 
+    public function testItGetsAuditedTypeAttribute()
+    {
+        $auditing = new Auditing();
+
+        $auditing->auditable = new EloquentModelStub();
+        $auditing->related_type = 'Fake\Relation';
+
+        $auditing->type = 'attached';
+        $this->assertNotEquals($auditing->audited_type, $auditing->type);
+
+        $auditing->type = 'attached';
+        $this->assertNotEquals($auditing->audited_type, $auditing->type);
+
+        $auditing->type = 'detached';
+        $this->assertNotEquals($auditing->audited_type, $auditing->type);
+
+        $auditing->type = 'nonsense';
+        $this->assertEquals($auditing->audited_type, $auditing->type);
+    }
+
     public function testItGetTableInConfig()
     {
         $this->setConfigTable('auditing');


### PR DESCRIPTION
This pull request basically adds auditing for many to many relationships on Eloquent models. Since Eloquent doesn't support event hooks on many to many relationships out of the box I "borrowed" some code from a pull request which was denied on laravel core and made it suitable for this package. If these events are ever added (the reason for denying the pull request didn't make it seem that they ever would) this will need to be refactored. But for now it works like a charm.