### PR TITLE
feature/message-translations

### DIFF
--- a/lang/en/auditing.php
+++ b/lang/en/auditing.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auditing Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the Auditing package.
+    | Feel free to modify these language lines according to your application's 
+    | requirements.
+    |
+    */
+
+    'undefined' => [
+        'message' => 'No custom message defined.',
+    ],
+
+];

--- a/lang/en/auditing.php
+++ b/lang/en/auditing.php
@@ -8,7 +8,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the Auditing package.
-    | Feel free to modify these language lines according to your application's 
+    | Feel free to modify these language lines according to your application's
     | requirements.
     |
     */

--- a/src/AuditingServiceProvider.php
+++ b/src/AuditingServiceProvider.php
@@ -39,7 +39,7 @@ class AuditingServiceProvider extends ServiceProvider
         if ($app->runningInConsole()) {
             $this->publishes([
                 $config      => config_path('auditing.php'),
-                $translation => resource_path('lang/en/auditing.php')
+                $translation => resource_path('lang/en/auditing.php'),
             ]);
         }
 

--- a/src/AuditingServiceProvider.php
+++ b/src/AuditingServiceProvider.php
@@ -33,13 +33,17 @@ class AuditingServiceProvider extends ServiceProvider
      */
     protected function setupConfig($app)
     {
-        $source = realpath(__DIR__.'/../config/auditing.php');
+        $config = realpath(__DIR__.'/../config/auditing.php');
+        $translation = realpath(__DIR__.'/../lang/en/auditing.php');
 
         if ($app->runningInConsole()) {
-            $this->publishes([$source => config_path('auditing.php')]);
+            $this->publishes([
+                $config      => config_path('auditing.php'),
+                $translation => resource_path('lang/en/auditing.php')
+            ]);
         }
 
-        $this->mergeConfigFrom($source, 'auditing');
+        $this->mergeConfigFrom($config, 'auditing');
     }
 
     /**

--- a/src/CustomAuditMessage.php
+++ b/src/CustomAuditMessage.php
@@ -3,11 +3,14 @@
 namespace OwenIt\Auditing;
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Lang;
 
 trait CustomAuditMessage
 {
     /**
      * Get the auditable entity that the audits belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function auditable()
     {
@@ -43,9 +46,9 @@ trait CustomAuditMessage
     {
         if (class_exists($class = $this->auditable_type)) {
             return $this->resolveCustomMessage($this->getCustomMessage($class));
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -80,16 +83,16 @@ trait CustomAuditMessage
     public function getCustomMessage($class)
     {
         if (!isset($class::$auditCustomMessage)) {
-            return 'Not defined custom message!';
+            return Lang::get('auditing.undefined.message');
         }
 
-        return $class::$auditCustomMessage;
+        return Lang::get($class::$auditCustomMessage);
     }
 
     /**
      * Get custom fields.
      *
-     * @return string
+     * @return array
      */
     public function getCustomFields($class)
     {
@@ -97,14 +100,13 @@ trait CustomAuditMessage
             return [];
         }
 
-        return $class::$auditCustomFields;
+        return Lang::get($class::$auditCustomFields);
     }
 
     /**
      * Resolve custom message.
      *
-     * @param $message
-     *
+     * @param  string $message
      * @return mixed
      */
     public function resolveCustomMessage($message)

--- a/src/CustomAuditMessage.php
+++ b/src/CustomAuditMessage.php
@@ -106,7 +106,8 @@ trait CustomAuditMessage
     /**
      * Resolve custom message.
      *
-     * @param  string $message
+     * @param string $message
+     *
      * @return mixed
      */
     public function resolveCustomMessage($message)


### PR DESCRIPTION
Hello!

This PR adds initial message translation support, as suggested in issue #143.

The changes are very simple and for the time being it should be fine, since the BC breaks are minimal.

I do however, suggest leveraging on the Symfony [translation component](http://symfony.com/doc/current/components/translation.html), which Laravel uses btw, to simplify the `CustomAuditMessage` trait.

But that can be done in another PR, since the syntax would have to change slightly: `{foo}` vs `:foo`.

**PS:** the documentation should also be updated to reflect changes, if this gets merged.