### PR TITLE
[4.0] fix/auditable-exclusions

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -58,7 +58,7 @@ return [
     | Audit Console?
     |--------------------------------------------------------------------------
     |
-    | Whether we should audit queries run through console (eg. php artisan db:seed).
+    | Whether we should audit console events (eg. php artisan db:seed).
     |
     */
 

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -63,7 +63,7 @@ trait Auditable
     protected $auditEvent;
 
     /**
-     * Auditable boot.
+     * Auditable boot logic.
      *
      * @return void
      */
@@ -144,9 +144,11 @@ trait Auditable
      */
     protected function auditUpdatedAttributes(array &$old, array &$new)
     {
-        foreach ($this->getModifiedAttributes() as $attribute => $value) {
-            $old[$attribute] = array_get($this->original, $attribute);
-            $new[$attribute] = array_get($this->attributes, $attribute);
+        foreach ($this->getDirty() as $attribute => $value) {
+            if ($this->isAttributeAuditable($attribute)) {
+                $old[$attribute] = array_get($this->original, $attribute);
+                $new[$attribute] = array_get($this->attributes, $attribute);
+            }
         }
     }
 
@@ -260,24 +262,6 @@ trait Auditable
         }
 
         return Request::fullUrl();
-    }
-
-    /**
-     * Get the modified attributes.
-     *
-     * @return array
-     */
-    private function getModifiedAttributes()
-    {
-        $modified = [];
-
-        foreach ($this->getDirty() as $attribute => $value) {
-            if ($this->isAttributeAuditable($attribute)) {
-                $modified[$attribute] = $value;
-            }
-        }
-
-        return $modified;
     }
 
     /**

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -95,8 +95,9 @@ trait Auditable
         if ($this->auditStrict) {
             $this->auditExclude = array_merge($this->auditExclude, $this->hidden);
 
-            if (!empty($this->visible)) {
-                $this->auditExclude = array_diff(array_keys($this->attributes), $this->visible);
+            if (count($this->visible)) {
+                $invisible = array_diff(array_keys($this->attributes), $this->visible);
+                $this->auditExclude = array_merge($this->auditExclude, $invisible);
             }
         }
 

--- a/src/Console/AuditDriverMakeCommand.php
+++ b/src/Console/AuditDriverMakeCommand.php
@@ -14,7 +14,7 @@ class AuditDriverMakeCommand extends GeneratorCommand
     /**
      * {@inheritdoc}
      */
-    protected $description = 'Create a new driver for auditing';
+    protected $description = 'Create a new audit driver';
 
     /**
      * {@inheritdoc}

--- a/src/Console/AuditTableCommand.php
+++ b/src/Console/AuditTableCommand.php
@@ -9,16 +9,12 @@ use Illuminate\Support\Composer;
 class AuditTableCommand extends Command
 {
     /**
-     * The console command name.
-     *
-     * @var string
+     * {@inheritdoc}
      */
     protected $name = 'auditing:table';
 
     /**
-     * The console command description.
-     *
-     * @var string
+     * {@inheritdoc}
      */
     protected $description = 'Create a migration for the audits table';
 
@@ -37,10 +33,7 @@ class AuditTableCommand extends Command
     protected $composer;
 
     /**
-     * Create a new audits table command instance.
-     *
-     * @param \Illuminate\Filesystem\Filesystem $files
-     * @param \Illuminate\Support\Composer      $composer
+     * {@inheritdoc}
      */
     public function __construct(Filesystem $files, Composer $composer)
     {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -9,16 +9,12 @@ use OwenIt\Auditing\AuditingServiceProvider;
 class InstallCommand extends Command
 {
     /**
-     * The console command name.
-     *
-     * @var string
+     * {@inheritdoc}
      */
     protected $name = 'auditing:install';
 
     /**
-     * The console command description.
-     *
-     * @var string
+     * {@inheritdoc}
      */
     protected $description = 'Install the Laravel Auditing package';
 

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -173,10 +173,12 @@ class Audit extends Model
      * Get the Audit metadata.
      *
      * @param bool $json
+     * @param int  $options
+     * @param int  $depth
      *
      * @return array
      */
-    public function getMetadata($json = false)
+    public function getMetadata($json = false, $options = 0, $depth = 512)
     {
         if (empty($this->data)) {
             $this->resolveData();
@@ -188,17 +190,19 @@ class Audit extends Model
             $metadata[$key] = $this->getDataValue($key);
         }
 
-        return $json ? json_encode($metadata) : $metadata;
+        return $json ? json_encode($metadata, $options, $depth) : $metadata;
     }
 
     /**
      * Get the Auditable modified attributes.
      *
      * @param bool $json
+     * @param int  $options
+     * @param int  $depth
      *
      * @return array
      */
-    public function getModified($json = false)
+    public function getModified($json = false, $options = 0, $depth = 512)
     {
         if (empty($this->data)) {
             $this->resolveData();
@@ -213,6 +217,6 @@ class Audit extends Model
             $modified[$attribute][$state] = $this->getDataValue($key);
         }
 
-        return $json ? json_encode($modified) : $modified;
+        return $json ? json_encode($modified, $options, $depth) : $modified;
     }
 }


### PR DESCRIPTION
In this PR:
- Make the exclusion logic for hidden/visible attributes behave as in version 3.x
- Allow `json_encode()` arguments to be passed via `getMetadata()` and `getModified()`
- Remove `getModifiedAttributes()` method