### PR TITLE
Interrogate database for counting rows for deletion only if model has historyLimit attribute set.

### DIFF
--- a/src/AuditingTrait.php
+++ b/src/AuditingTrait.php
@@ -250,14 +250,16 @@ trait AuditingTrait
      */
     private function clearOlderLogs()
     {
-        $logHistoryCount = $this->logHistory()->count();
-        $logHistoryOlder = $logHistoryCount - $this->historyLimit;
+        if (isset($this->historyLimit)) {
+            $logHistoryCount = $this->logHistory()->count();
+            $logHistoryOlder = $logHistoryCount - $this->historyLimit;
 
-        if (isset($this->historyLimit) && $logHistoryOlder > 0) {
-            $logs = $this->logHistory($logHistoryOlder, 'asc');
-            $logs->each(function ($log) {
-                $log->delete();
-            });
+            if ($logHistoryOlder > 0) {
+                $logs = $this->logHistory($logHistoryOlder, 'asc');
+                $logs->each(function ($log) {
+                    $log->delete();
+                });
+            }
         }
     }
 


### PR DESCRIPTION
If the historyLimit attribute is not set on the model then an unused database query will run and this can impact performance throughout the application. 