### PR TITLE
Fix migration stub to use configurations for database driver

### DIFF
--- a/src/Console/stubs/audits.stub
+++ b/src/Console/stubs/audits.stub
@@ -25,17 +25,18 @@ class CreateAuditsTable extends Migration
      */
     public function up()
     {
-        Schema::create('audits', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('user_id')->nullable();
-            $table->string('event');
-            $table->morphs('auditable');
-            $table->text('old_values')->nullable();
-            $table->text('new_values')->nullable();
-            $table->string('url')->nullable();
-            $table->ipAddress('ip_address')->nullable();
-            $table->timestamp('created_at');
-        });
+        Schema::connection(config('audit.drivers.database.connection'))
+            ->create(config('audit.drivers.database.table'), function (Blueprint $table) {
+                $table->increments('id');
+                $table->unsignedInteger('user_id')->nullable();
+                $table->string('event');
+                $table->morphs('auditable');
+                $table->text('old_values')->nullable();
+                $table->text('new_values')->nullable();
+                $table->string('url')->nullable();
+                $table->ipAddress('ip_address')->nullable();
+                $table->timestamp('created_at');
+            });
     }
 
     /**

--- a/src/Console/stubs/audits.stub
+++ b/src/Console/stubs/audits.stub
@@ -46,6 +46,7 @@ class CreateAuditsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('audits');
+        Schema::connection(config('audit.drivers.database.connection'))
+            ->drop(config('audit.drivers.database.table'));
     }
 }


### PR DESCRIPTION
This allows us to change database driver configuration before calling "php artisan migrate".