### PR TITLE
Added withTrashed to auditable relation and avoid logging item as updated when restoring

### DIFF
--- a/src/AuditableObserver.php
+++ b/src/AuditableObserver.php
@@ -41,6 +41,7 @@ class AuditableObserver
     public function updated(AuditableContract $model)
     {
         if (
+            method_exists($model, 'getDeletedAtColumn') &&
             $model->isDirty($model->getDeletedAtColumn()) &&
             !$model->deleted_at &&
             count($model->getDirty()) == 2 //deleted_at and updated_at

--- a/src/AuditableObserver.php
+++ b/src/AuditableObserver.php
@@ -40,7 +40,16 @@ class AuditableObserver
      */
     public function updated(AuditableContract $model)
     {
-        Auditor::execute($model->setAuditEvent('updated'));
+        if (
+            $model->isDirty($model->getDeletedAtColumn()) &&
+            !$model->deleted_at &&
+            count($model->getDirty()) == 2 //deleted_at and updated_at
+        ){
+            // only restoring softdeleted item, no values changed other than deleted_at an updated_at
+        }
+        else {
+            Auditor::execute($model->setAuditEvent('updated'));
+        }
     }
 
     /**

--- a/src/AuditableObserver.php
+++ b/src/AuditableObserver.php
@@ -44,10 +44,9 @@ class AuditableObserver
             $model->isDirty($model->getDeletedAtColumn()) &&
             !$model->deleted_at &&
             count($model->getDirty()) == 2 //deleted_at and updated_at
-        ){
+        ) {
             // only restoring softdeleted item, no values changed other than deleted_at an updated_at
-        }
-        else {
+        } else {
             Auditor::execute($model->setAuditEvent('updated'));
         }
     }

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -93,7 +93,7 @@ class Audit extends Model
      */
     public function auditable()
     {
-        return $this->morphTo();
+        return $this->morphTo()->withTrashed();
     }
 
     /**


### PR DESCRIPTION
When retreiving a softdeleted item, I was getting an error, so I added withTrashed when at the auditable() relation. This is because I am auditing a model and some related models using many to many relationships (which required a few changes and not using the sync() method.

Also, when restoring a softdeleted item, an updated audit was being created. I added some logic to check if only the updated_at and deleted_at are changing (with deleted_at being not null) before saving an updated audit.