### PR TITLE
Fix for issue #226

### DIFF
--- a/src/Console/stubs/driver.stub
+++ b/src/Console/stubs/driver.stub
@@ -12,13 +12,13 @@
  * with this source code.
  */
 
-namespace App\AuditDrivers;
+namespace DummyNamespace;
 
 use OwenIt\Auditing\Contracts\Auditable;
 use OwenIt\Auditing\Contracts\AuditDriver;
 use OwenIt\Auditing\Models\Audit;
 
-class CustomDriver implements AuditDriver
+class DummyClass implements AuditDriver
 {
     /**
      * Perform an audit.


### PR DESCRIPTION
Put back the `DummyNamespace` and `DummyClass` replacement string so that the  `AuditDriverMakeCommand` works as expected.