### PR TITLE
[FIX] Remove explicit sort from the audits relation

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -58,9 +58,7 @@ trait Auditable
      */
     public function audits()
     {
-        return $this->morphMany(AuditModel::class, 'auditable')
-            ->distinct('created_at')
-            ->orderBy('created_at', 'DESC');
+        return $this->morphMany(AuditModel::class, 'auditable');
     }
 
     /**


### PR DESCRIPTION
Setting a default sort order for the `audits()` relation method in the `Auditable` trait has been causing issues in a few RDBMS.

From now on, users who want to change the default sorting behaviour (`created_at` ASC), will have to do it themselves taking into account the RDBMS they're using.