### PR TITLE
Change URL type string to text

### DIFF
--- a/src/Console/stubs/audits.stub
+++ b/src/Console/stubs/audits.stub
@@ -33,7 +33,7 @@ class CreateAuditsTable extends Migration
                 $table->morphs('auditable');
                 $table->text('old_values')->nullable();
                 $table->text('new_values')->nullable();
-                $table->string('url')->nullable();
+                $table->text('url')->nullable();
                 $table->ipAddress('ip_address')->nullable();
                 $table->string('user_agent')->nullable();
                 $table->timestamp('created_at');


### PR DESCRIPTION
I had the problem when using socialite facebook the route url was to long for the database. I changed the type to text so the URL could fit.

Error message:

`SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'url' at row 1`