### PR TITLE
Fix iterating over all audits, if audible model is not resolved

### DIFF
--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -162,7 +162,7 @@ class Audit extends Model
         $value = $this->data[$key];
 
         // Apply a mutator or a cast the Auditable model may have defined
-        if (starts_with($key, ['new_', 'old_'])) {
+        if ($this->auditable && starts_with($key, ['new_', 'old_'])) {
             $originalKey = substr($key, 4);
 
             if ($this->auditable->hasGetMutator($originalKey)) {


### PR DESCRIPTION
Possible fix for #206, not tested for side-effects, but seems to run OK with local dataset.