### PR TITLE
Related relations

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -200,24 +200,101 @@ trait Auditable
         $this->updateAuditExclusions();
 
         $old = [];
-        $new = [];
+        $new              = [];
+        $related_relations_arr = $this->generateRelatedRelations();
 
         $this->{$method}($old, $new);
 
-        return $this->transformAudit([
-            'old_values'     => $old,
-            'new_values'     => $new,
-            'event'          => $this->auditEvent,
-            'auditable_id'   => $this->getKey(),
-            'auditable_type' => $this->getMorphClass(),
-            'user_id'        => $this->resolveUserId(),
-            'url'            => $this->resolveUrl(),
-            'ip_address'     => $this->resolveIpAddress(),
-            'user_agent'     => $this->resolveUserAgent(),
-            'created_at'     => $this->freshTimestamp(),
-        ]);
+        return $this->transformAudit(
+            [
+                'old_values'             => $old,
+                'new_values'             => $new,
+                'event'                  => $this->auditEvent,
+                'auditable_id'           => $this->getKey(),
+                'auditable_type'         => $this->getMorphClass(),
+                'user_id'                => $this->resolveUserId(),
+                'url'                    => $this->resolveUrl(),
+                'ip_address'             => $this->resolveIpAddress(),
+                'user_agent'             => $this->resolveUserAgent(),
+                'related_relations_json' => json_encode($related_relations_arr),
+                'created_at'             => $this->freshTimestamp(),
+            ]
+        );
     }
 
+    public function generateRelatedRelations()
+    {
+        $related_relations_arr        = [];
+        $broad_relationship_types_arr = ['BelongsTo', 'HasMany', 'BelongsToMany', 'HasOne'];
+
+        if ( ! $this->auditIncludeRelated)
+        {
+            return $related_relations_arr;
+        }
+        foreach ($broad_relationship_types_arr as $broad_relationship)
+        {
+
+            $broad_relationship_method = 'get'.ucfirst($broad_relationship) . 'Arr';
+            if ( ! method_exists($this, $broad_relationship_method))
+            {
+                continue;
+            }
+            $related_relations_arr[$broad_relationship] = [];
+            $relationship_arr                           = $this->$broad_relationship_method();
+            foreach ($relationship_arr as $relationship)
+            {
+                if ( ! method_exists($this, $relationship))
+                {
+                    continue;
+                }
+                $RelationshipObjArr = $this->$relationship;
+                if ( ! is_iterable($RelationshipObjArr))
+                {
+                    $RelationshipObjArr = [$RelationshipObjArr];
+                }
+                foreach ($RelationshipObjArr as $RelationshipObj)
+                {
+                    foreach ([ 'BelongsToMany', 'HasOne'] as $broad_relationshipx)
+                    {
+                        if($broad_relationshipx == $broad_relationship)
+                        {
+                            $x=1;
+                        }
+                    }
+                    if(! is_object($RelationshipObj) && $relationship != 'propertyGroup')
+                    {
+                        $x=1;
+                    }
+                    if(! is_object($RelationshipObj))
+                    {
+                        $x=1;
+                    }
+                    $related_relations_iten_arr = [
+
+                        'type'               => $broad_relationship,
+                        'source_relation'    => get_class($this),
+                        'source_relation_id' => $this->{$this->primaryKey},
+                    ];
+                    if($RelationshipObj == null)
+                    {
+                        /**
+                         * this can happen when a foreign key constraint referances the self-same table.
+                         */
+                        $x=1;
+                    }
+                    else
+                    {
+                        $related_relations_iten_arr['target_relation'] = get_class($RelationshipObj);
+                        $related_relations_iten_arr['target_relation_id'] = $RelationshipObj->{$this->primaryKey};
+                    }
+                    $related_relations_arr[$broad_relationship][]    = $related_relations_iten_arr;
+
+                }
+            }
+        }
+
+        return $related_relations_arr;
+    }
     /**
      * {@inheritdoc}
      */

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -254,21 +254,6 @@ trait Auditable
                 }
                 foreach ($RelationshipObjArr as $RelationshipObj)
                 {
-                    foreach ([ 'BelongsToMany', 'HasOne'] as $broad_relationshipx)
-                    {
-                        if($broad_relationshipx == $broad_relationship)
-                        {
-                            $x=1;
-                        }
-                    }
-                    if(! is_object($RelationshipObj) && $relationship != 'propertyGroup')
-                    {
-                        $x=1;
-                    }
-                    if(! is_object($RelationshipObj))
-                    {
-                        $x=1;
-                    }
                     $related_relations_iten_arr = [
 
                         'type'               => $broad_relationship,

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -227,7 +227,7 @@ trait Auditable
         $related_relations_arr        = [];
         $broad_relationship_types_arr = ['BelongsTo', 'HasMany', 'BelongsToMany', 'HasOne'];
 
-        if ( ! $this->auditIncludeRelated)
+        if (! property_exists($this,'auditIncludeRelated') ||  ! $this->auditIncludeRelated)
         {
             return $related_relations_arr;
         }
@@ -265,7 +265,6 @@ trait Auditable
                         /**
                          * this can happen when a foreign key constraint referances the self-same table.
                          */
-                        $x=1;
                     }
                     else
                     {

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -200,7 +200,7 @@ trait Auditable
         $this->updateAuditExclusions();
 
         $old = [];
-        $new              = [];
+        $new = [];
         $related_relations_arr = $this->generateRelatedRelations();
 
         $this->{$method}($old, $new);
@@ -224,61 +224,50 @@ trait Auditable
 
     public function generateRelatedRelations()
     {
-        $related_relations_arr        = [];
+        $related_relations_arr = [];
         $broad_relationship_types_arr = ['BelongsTo', 'HasMany', 'BelongsToMany', 'HasOne'];
 
-        if (! property_exists($this,'auditIncludeRelated') ||  ! $this->auditIncludeRelated)
-        {
+        if (!property_exists($this, 'auditIncludeRelated') || !$this->auditIncludeRelated) {
             return $related_relations_arr;
         }
-        foreach ($broad_relationship_types_arr as $broad_relationship)
-        {
-
-            $broad_relationship_method = 'get'.ucfirst($broad_relationship) . 'Arr';
-            if ( ! method_exists($this, $broad_relationship_method))
-            {
+        foreach ($broad_relationship_types_arr as $broad_relationship) {
+            $broad_relationship_method = 'get'.ucfirst($broad_relationship).'Arr';
+            if (!method_exists($this, $broad_relationship_method)) {
                 continue;
             }
             $related_relations_arr[$broad_relationship] = [];
-            $relationship_arr                           = $this->$broad_relationship_method();
-            foreach ($relationship_arr as $relationship)
-            {
-                if ( ! method_exists($this, $relationship))
-                {
+            $relationship_arr = $this->$broad_relationship_method();
+            foreach ($relationship_arr as $relationship) {
+                if (!method_exists($this, $relationship)) {
                     continue;
                 }
                 $RelationshipObjArr = $this->$relationship;
-                if ( ! is_iterable($RelationshipObjArr))
-                {
+                if (!is_iterable($RelationshipObjArr)) {
                     $RelationshipObjArr = [$RelationshipObjArr];
                 }
-                foreach ($RelationshipObjArr as $RelationshipObj)
-                {
+                foreach ($RelationshipObjArr as $RelationshipObj) {
                     $related_relations_iten_arr = [
 
                         'type'               => $broad_relationship,
                         'source_relation'    => get_class($this),
                         'source_relation_id' => $this->{$this->primaryKey},
                     ];
-                    if($RelationshipObj == null)
-                    {
-                        /**
+                    if ($RelationshipObj == null) {
+                        /*
                          * this can happen when a foreign key constraint referances the self-same table.
                          */
-                    }
-                    else
-                    {
+                    } else {
                         $related_relations_iten_arr['target_relation'] = get_class($RelationshipObj);
                         $related_relations_iten_arr['target_relation_id'] = $RelationshipObj->{$this->primaryKey};
                     }
-                    $related_relations_arr[$broad_relationship][]    = $related_relations_iten_arr;
-
+                    $related_relations_arr[$broad_relationship][] = $related_relations_iten_arr;
                 }
             }
         }
 
         return $related_relations_arr;
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Console/AuditTableCommand.php
+++ b/src/Console/AuditTableCommand.php
@@ -65,6 +65,7 @@ class AuditTableCommand extends Command
         $fullPath = $this->createBaseMigration();
 
         $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/audits.stub'));
+        $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/audit_relations.stub'));
 
         $this->info('Migration created successfully!');
 

--- a/src/Console/stubs/audit_relations.stub
+++ b/src/Console/stubs/audit_relations.stub
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the Laravel Auditing package.
+ *
+ * @author     Antério Vieira <anteriovieira@gmail.com>
+ * @author     Quetzy Garcia  <quetzyg@altek.org>
+ * @author     Raphael França <raphaelfrancabsb@gmail.com>
+ * @copyright  2015-2017
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE.md file that was distributed
+ * with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAuditRelationsJson extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(
+            'audits',
+            function (Blueprint $table)
+            {
+                /** @noinspection PhpUndefinedMethodInspection */
+                $table->text('related_relations_json')->after('ip_address');
+            }
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('audits',
+            function (Blueprint $table)
+            {
+                $table->dropColumn('related_relations_json');
+            }
+        );
+    }
+}

--- a/tests/AuditableTest.php
+++ b/tests/AuditableTest.php
@@ -134,7 +134,7 @@ class AuditableTest extends TestCase
         $auditData = $model->toAudit();
 
         // Audit attributes
-        $this->assertCount(10, $auditData);
+        $this->assertCount(11, $auditData);
 
         $this->assertArrayHasKey('old_values', $auditData);
         $this->assertArrayHasKey('new_values', $auditData);
@@ -145,6 +145,7 @@ class AuditableTest extends TestCase
         $this->assertArrayHasKey('url', $auditData);
         $this->assertArrayHasKey('ip_address', $auditData);
         $this->assertArrayHasKey('user_agent', $auditData);
+        $this->assertArrayHasKey('related_relations_json', $auditData);
         $this->assertArrayHasKey('created_at', $auditData);
 
         // Modified Auditable attributes
@@ -175,7 +176,7 @@ class AuditableTest extends TestCase
         $auditData = $model->toAudit();
 
         // Audit attributes
-        $this->assertCount(11, $auditData);
+        $this->assertCount(12, $auditData);
 
         $this->assertArrayHasKey('old_values', $auditData);
         $this->assertArrayHasKey('new_values', $auditData);
@@ -186,6 +187,7 @@ class AuditableTest extends TestCase
         $this->assertArrayHasKey('url', $auditData);
         $this->assertArrayHasKey('ip_address', $auditData);
         $this->assertArrayHasKey('user_agent', $auditData);
+        $this->assertArrayHasKey('related_relations_json', $auditData);
         $this->assertArrayHasKey('created_at', $auditData);
         $this->assertArrayHasKey('foo', $auditData);
     }
@@ -216,7 +218,7 @@ class AuditableTest extends TestCase
         ], $model->getAuditInclude());
 
         // Audit attributes
-        $this->assertCount(10, $auditData);
+        $this->assertCount(11, $auditData);
 
         $this->assertArrayHasKey('old_values', $auditData);
         $this->assertArrayHasKey('new_values', $auditData);
@@ -227,6 +229,7 @@ class AuditableTest extends TestCase
         $this->assertArrayHasKey('url', $auditData);
         $this->assertArrayHasKey('ip_address', $auditData);
         $this->assertArrayHasKey('user_agent', $auditData);
+        $this->assertArrayHasKey('related_relations_json', $auditData);
         $this->assertArrayHasKey('created_at', $auditData);
 
         // Modified Auditable attributes
@@ -259,7 +262,7 @@ class AuditableTest extends TestCase
         ], $model->getAuditExclude());
 
         // Audit attributes
-        $this->assertCount(10, $auditData);
+        $this->assertCount(11, $auditData);
 
         $this->assertArrayHasKey('old_values', $auditData);
         $this->assertArrayHasKey('new_values', $auditData);
@@ -270,6 +273,7 @@ class AuditableTest extends TestCase
         $this->assertArrayHasKey('url', $auditData);
         $this->assertArrayHasKey('ip_address', $auditData);
         $this->assertArrayHasKey('user_agent', $auditData);
+        $this->assertArrayHasKey('related_relations_json', $auditData);
         $this->assertArrayHasKey('created_at', $auditData);
 
         // Modified Auditable attributes
@@ -302,7 +306,7 @@ class AuditableTest extends TestCase
         $this->assertTrue($model->getAuditTimestamps());
 
         // Audit attributes
-        $this->assertCount(10, $auditData);
+        $this->assertCount(11, $auditData);
 
         $this->assertArrayHasKey('old_values', $auditData);
         $this->assertArrayHasKey('new_values', $auditData);
@@ -313,6 +317,7 @@ class AuditableTest extends TestCase
         $this->assertArrayHasKey('url', $auditData);
         $this->assertArrayHasKey('ip_address', $auditData);
         $this->assertArrayHasKey('user_agent', $auditData);
+        $this->assertArrayHasKey('related_relations_json', $auditData);
         $this->assertArrayHasKey('created_at', $auditData);
 
         // Modified Auditable attributes
@@ -352,7 +357,7 @@ class AuditableTest extends TestCase
         $this->assertTrue($model->getAuditStrict());
 
         // Audit attributes
-        $this->assertCount(10, $auditData);
+        $this->assertCount(11, $auditData);
 
         $this->assertArrayHasKey('old_values', $auditData);
         $this->assertArrayHasKey('new_values', $auditData);
@@ -363,6 +368,7 @@ class AuditableTest extends TestCase
         $this->assertArrayHasKey('url', $auditData);
         $this->assertArrayHasKey('ip_address', $auditData);
         $this->assertArrayHasKey('user_agent', $auditData);
+        $this->assertArrayHasKey('related_relations_json', $auditData);
         $this->assertArrayHasKey('created_at', $auditData);
 
         // Modified Auditable attributes
@@ -400,7 +406,7 @@ class AuditableTest extends TestCase
         $this->assertTrue($model->getAuditStrict());
 
         // Audit attributes
-        $this->assertCount(10, $auditData);
+        $this->assertCount(11, $auditData);
 
         $this->assertArrayHasKey('old_values', $auditData);
         $this->assertArrayHasKey('new_values', $auditData);
@@ -411,6 +417,7 @@ class AuditableTest extends TestCase
         $this->assertArrayHasKey('url', $auditData);
         $this->assertArrayHasKey('ip_address', $auditData);
         $this->assertArrayHasKey('user_agent', $auditData);
+        $this->assertArrayHasKey('related_relations_json', $auditData);
         $this->assertArrayHasKey('created_at', $auditData);
 
         // Modified Auditable attributes


### PR DESCRIPTION
This pull request is my initial attempt to audit the relationships of a particular model. Please comment but I am unwilling to push this intil I deal with the 3 Todo's.

Be warned: This can have negative impact on DB performance. Be very cautious to not use this feature on too many models (and those models relationships). This PR offers controls on both.

Todo: 
Create table related_relations and use this rather that audits:related_relation_json
Integrate this into $model->audits()
Better unit tests

Todo (far future)
Make this Event/Queue friendly to try to deal w/ the DB load this this can generate.

To use:

Run the migration adding related_relation_json to audits table

All models for which you want to track related_relations need: 

1. A public property of $model->auditIncludeRelated set to true
1. These public methods: $model->getBelongsToArr(), $model->HasManyArr,$model->GetBelongsToManyArr(), $model->getHasOneArr(). These should return an array of strings that indicate the names of the Eloquent properties (relations) you wish to track.
1. If you are auditing the related models of $a (say $b and $c), you minimally need to audit $b and $c. 


 
