### PR TITLE
Audits updated_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v4.1.0 (2017-07-??)
 ### Added
 - Implemented Audit contract, enabling classes to extend other model types ([#211](https://github.com/owen-it/laravel-auditing/issues/211))
+- The `updated_at` attribute is now part of the Audit model. Don't forget to update your `audits` table!
 
 ### Fixed
 - Allow the User primary and foreign key to be specified in the configuration ([#251](https://github.com/owen-it/laravel-auditing/issues/251))

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -88,6 +88,7 @@ trait Audit
             'audit_ip_address' => $this->ip_address,
             'audit_user_agent' => $this->user_agent,
             'audit_created_at' => $this->serializeDate($this->created_at),
+            'audit_updated_at' => $this->serializeDate($this->updated_at),
             'user_id'          => $this->user_id,
         ];
 

--- a/src/Console/stubs/audits.stub
+++ b/src/Console/stubs/audits.stub
@@ -36,7 +36,7 @@ class CreateAuditsTable extends Migration
                 $table->string('url')->nullable();
                 $table->ipAddress('ip_address')->nullable();
                 $table->string('user_agent')->nullable();
-                $table->timestamp('created_at');
+                $table->timestamps();
             });
     }
 

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -25,19 +25,7 @@ class Audit extends Model implements AuditContract
     /**
      * {@inheritdoc}
      */
-    public $timestamps = false;
-
-    /**
-     * {@inheritdoc}
-     */
     protected $guarded = [];
-
-    /**
-     * {@inheritdoc}
-     */
-    protected $dates = [
-        'created_at',
-    ];
 
     /**
      * {@inheritdoc}

--- a/tests/AuditModelTest.php
+++ b/tests/AuditModelTest.php
@@ -31,12 +31,15 @@ class AuditModelTest extends TestCase
      */
     private function setAuditTestAttributes(Audit $audit)
     {
+        $now = Carbon::now();
+
         $audit->id = 1;
         $audit->event = 'created';
         $audit->url = 'http://example.com/create';
         $audit->ip_address = '127.0.0.1';
         $audit->user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0';
-        $audit->created_at = Carbon::now();
+        $audit->created_at = $now;
+        $audit->updated_at = $now;
         $audit->user_id = 1;
         $audit->new_values = [
             'title'     => 'How To Audit Eloquent Models',
@@ -62,7 +65,7 @@ class AuditModelTest extends TestCase
 
         $data = $audit->resolveData();
 
-        $this->assertCount(13, $data);
+        $this->assertCount(14, $data);
 
         $this->assertArrayHasKey('audit_id', $data);
         $this->assertArrayHasKey('audit_event', $data);
@@ -70,6 +73,7 @@ class AuditModelTest extends TestCase
         $this->assertArrayHasKey('audit_ip_address', $data);
         $this->assertArrayHasKey('audit_user_agent', $data);
         $this->assertArrayHasKey('audit_created_at', $data);
+        $this->assertArrayHasKey('audit_updated_at', $data);
         $this->assertArrayHasKey('user_id', $data);
         $this->assertArrayHasKey('new_title', $data);
         $this->assertArrayHasKey('new_content', $data);
@@ -126,7 +130,7 @@ class AuditModelTest extends TestCase
 
         $metadata = $audit->getMetadata();
 
-        $this->assertCount(7, $metadata);
+        $this->assertCount(8, $metadata);
 
         $this->assertArrayHasKey('audit_id', $metadata);
         $this->assertArrayHasKey('audit_event', $metadata);
@@ -134,6 +138,7 @@ class AuditModelTest extends TestCase
         $this->assertArrayHasKey('audit_ip_address', $metadata);
         $this->assertArrayHasKey('audit_ip_address', $metadata);
         $this->assertArrayHasKey('audit_created_at', $metadata);
+        $this->assertArrayHasKey('audit_updated_at', $metadata);
         $this->assertArrayHasKey('user_id', $metadata);
     }
 
@@ -161,6 +166,7 @@ class AuditModelTest extends TestCase
     "audit_ip_address": "127.0.0.1",
     "audit_user_agent": "Mozilla\/5.0 (X11; Linux x86_64; rv:53.0) Gecko\/20100101 Firefox\/53.0",
     "audit_created_at": "$now",
+    "audit_updated_at": "$now",
     "user_id": 1
 }
 EOF;


### PR DESCRIPTION
Work done in this pull request:
- Added the `updated_at` column to the `audits` table migration;

This also simplifies the `Audit` model implementation, which won't require the `$timestamps` and `$dates` attributes to be set anymore.

Don't forget to update your `audits` table, when upgrading!