### PR TITLE
Ensure $this->user is not null

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -92,7 +92,7 @@ trait Audit
             'user_id'          => $this->getAttribute(Config::get('audit.user.foreign_key', 'user_id')),
         ];
 
-        if ($this->relationLoaded('user')) {
+        if ($this->relationLoaded('user') && $this->user) {
             foreach ($this->user->attributesToArray() as $attribute => $value) {
                 $this->data['user_'.$attribute] = $value;
             }


### PR DESCRIPTION
I ran into an issue where if I modify an audited model without a user (ie. from the CLI) and then try and grab the audits it throws:
`PHP Fatal error:  Call to a member function attributesToArray() on null in [...]/vendor/owen-it/laravel-auditing/src/Models/Audit.php on line 128`

This modification ensures there is a user set before calling `$this->user->attributesToArray()` therefor avoiding the fatal error