### PR TITLE
Change user_agent column to be text, not string

### DIFF
--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -34,7 +34,7 @@ class CreateAuditsTable extends Migration
                 $table->morphs('auditable');
                 $table->text('old_values')->nullable();
                 $table->text('new_values')->nullable();
-                $table->string('url')->nullable();
+                $table->text('url')->nullable();
                 $table->ipAddress('ip_address')->nullable();
                 $table->string('user_agent')->nullable();
                 $table->timestamps();


### PR DESCRIPTION
User Agents aren't necessarily fewer than 255 chars. I've been getting a few `Data too long for column 'user_agent'` exceptions on productions, and that causes a method to exit out after `->save()` is called on the modal 😢 