### PR TITLE
Remove static reference to OwenIt\Auditing\Models\Audit in Database driver

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -14,9 +14,9 @@
 
 namespace OwenIt\Auditing\Drivers;
 
+use Illuminate\Support\Facades\Config;
 use OwenIt\Auditing\Contracts\Auditable;
 use OwenIt\Auditing\Contracts\AuditDriver;
-use Illuminate\Support\Facades\Config;
 
 class Database implements AuditDriver
 {
@@ -29,7 +29,7 @@ class Database implements AuditDriver
         
         return $class::create($model->toAudit());
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -37,19 +37,19 @@ class Database implements AuditDriver
     {
         if (($threshold = $model->getAuditThreshold()) > 0) {
             $total = $model->audits()->count();
-            
+
             $forRemoval = ($total - $threshold);
-            
+
             if ($forRemoval > 0) {
                 $model->audits()
                     ->orderBy('created_at', 'asc')
                     ->limit($forRemoval)
                     ->delete();
-                
+
                 return true;
             }
         }
-        
+
         return false;
     }
 }

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -26,7 +26,7 @@ class Database implements AuditDriver
     public function audit(Auditable $model)
     {
         $class = Config::get('audit.implementation', \OwenIt\Auditing\Models\Audit::class);
-        
+
         return $class::create($model->toAudit());
     }
 

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -26,9 +26,10 @@ class Database implements AuditDriver
     public function audit(Auditable $model)
     {
         $class = Config::get('audit.implementation', \OwenIt\Auditing\Models\Audit::class);
+        
         return $class::create($model->toAudit());
     }
-
+    
     /**
      * {@inheritdoc}
      */
@@ -36,19 +37,19 @@ class Database implements AuditDriver
     {
         if (($threshold = $model->getAuditThreshold()) > 0) {
             $total = $model->audits()->count();
-
+            
             $forRemoval = ($total - $threshold);
-
+            
             if ($forRemoval > 0) {
                 $model->audits()
                     ->orderBy('created_at', 'asc')
                     ->limit($forRemoval)
                     ->delete();
-
+                
                 return true;
             }
         }
-
+        
         return false;
     }
 }

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -16,7 +16,7 @@ namespace OwenIt\Auditing\Drivers;
 
 use OwenIt\Auditing\Contracts\Auditable;
 use OwenIt\Auditing\Contracts\AuditDriver;
-use OwenIt\Auditing\Models\Audit;
+use Illuminate\Support\Facades\Config;
 
 class Database implements AuditDriver
 {
@@ -25,7 +25,8 @@ class Database implements AuditDriver
      */
     public function audit(Auditable $model)
     {
-        return Audit::create($model->toAudit());
+        $class = Config::get('audit.implementation', \OwenIt\Auditing\Models\Audit::class);
+        return $class::create($model->toAudit());
     }
 
     /**


### PR DESCRIPTION
Database driver still constructs static OwenIt\Auditing\Models\Audit class instead of using the configured Model class in 'audit.implementation' section of config file.  

This is required so I can override the Audit model and store Audit trail in Mongo database store using my own model implementation.