### PR TITLE
fix recursive array issue

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -132,7 +132,7 @@ trait Auditable
         }
     }
 
-    function recursiveUpdatedAttributes(array $value, $attribute, &$old, &$new)
+    public function recursiveUpdatedAttributes(array $value, $attribute, &$old, &$new)
     {
         foreach ($value as $attr => $val) {
             if ($this->isAttributeAuditable($attribute)) {
@@ -211,15 +211,15 @@ trait Auditable
         $foreignKey = Config::get('audit.user.foreign_key', 'user_id');
 
         return $this->transformAudit([
-            'old_values' => $old,
-            'new_values' => $new,
-            'event' => $this->auditEvent,
-            'auditable_id' => $this->getKey(),
-            'auditable_type' => $this->getMorphClass(),
-            $foreignKey => $this->resolveUserId(),
-            'url' => $this->resolveUrl(),
-            'ip_address' => $this->resolveIpAddress(),
-            'user_agent' => $this->resolveUserAgent(),
+            'old_values'        => $old,
+            'new_values'        => $new,
+            'event'             => $this->auditEvent,
+            'auditable_id'      => $this->getKey(),
+            'auditable_type'    => $this->getMorphClass(),
+            $foreignKey         => $this->resolveUserId(),
+            'url'               => $this->resolveUrl(),
+            'ip_address'        => $this->resolveIpAddress(),
+            'user_agent'        => $this->resolveUserAgent(),
         ]);
     }
 
@@ -357,7 +357,7 @@ trait Auditable
     public static function isAuditingEnabled()
     {
         if (App::runningInConsole()) {
-            return (bool)Config::get('audit.console', false);
+            return (bool) Config::get('audit.console', false);
         }
 
         return true;
@@ -368,7 +368,7 @@ trait Auditable
      */
     public function getAuditInclude()
     {
-        return isset($this->auditInclude) ? (array)$this->auditInclude : [];
+        return isset($this->auditInclude) ? (array) $this->auditInclude : [];
     }
 
     /**
@@ -376,7 +376,7 @@ trait Auditable
      */
     public function getAuditExclude()
     {
-        return isset($this->auditExclude) ? (array)$this->auditExclude : [];
+        return isset($this->auditExclude) ? (array) $this->auditExclude : [];
     }
 
     /**
@@ -384,7 +384,7 @@ trait Auditable
      */
     public function getAuditStrict()
     {
-        return isset($this->auditStrict) ? (bool)$this->auditStrict : false;
+        return isset($this->auditStrict) ? (bool) $this->auditStrict : false;
     }
 
     /**
@@ -392,7 +392,7 @@ trait Auditable
      */
     public function getAuditTimestamps()
     {
-        return isset($this->auditTimestamps) ? (bool)$this->auditTimestamps : false;
+        return isset($this->auditTimestamps) ? (bool) $this->auditTimestamps : false;
     }
 
     /**

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -191,7 +191,7 @@ trait Auditable
             throw new RuntimeException('A valid audit event has not been set');
         }
 
-        $method = 'audit' . Str::studly($this->auditEvent) . 'Attributes';
+        $method = 'audit'.Str::studly($this->auditEvent).'Attributes';
 
         if (!method_exists($this, $method)) {
             throw new RuntimeException(sprintf(

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -131,9 +131,16 @@ trait Auditable
     protected function auditUpdatedAttributes(array &$old, array &$new)
     {
         foreach ($this->getDirty() as $attribute => $value) {
-            if ($this->isAttributeAuditable($attribute)) {
-                $old[$attribute] = array_get($this->original, $attribute);
-                $new[$attribute] = array_get($this->attributes, $attribute);
+            if (is_array($value)) {
+                foreach ($value as $attr => $val) {
+                    $old[$attribute][$attr] = array_get($this->original['settings'], $attr);
+                    $new[$attribute][$attr] = array_get($this->attributes['settings'], $attr);
+                }
+            } else {
+                if ($this->isAttributeAuditable($attribute)) {
+                    $old[$attribute] = array_get($this->original, $attribute);
+                    $new[$attribute] = array_get($this->attributes, $attribute);
+                }
             }
         }
     }

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -14,7 +14,6 @@
 
 namespace OwenIt\Auditing;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -133,8 +133,8 @@ trait Auditable
         foreach ($this->getDirty() as $attribute => $value) {
             if (is_array($value)) {
                 foreach ($value as $attr => $val) {
-                    $old[$attribute][$attr] = array_get($this->original['settings'], $attr);
-                    $new[$attribute][$attr] = array_get($this->attributes['settings'], $attr);
+                    $old[$attribute][$attr] = array_get($this->original[$attribute], $attr);
+                    $new[$attribute][$attr] = array_get($this->attributes[$attribute], $attr);
                 }
             } else {
                 if ($this->isAttributeAuditable($attribute)) {


### PR DESCRIPTION
Fixed if a field is an array then check it and save differency to audit table this is required when you use cast like object or array.