### PR TITLE
Fix url field too short bug

### DIFF
--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -34,7 +34,7 @@ class CreateAuditsTable extends Migration
                 $table->morphs('auditable');
                 $table->text('old_values')->nullable();
                 $table->text('new_values')->nullable();
-                $table->string('url')->nullable();
+                $table->text('url')->nullable();
                 $table->ipAddress('ip_address')->nullable();
                 $table->string('user_agent')->nullable();
                 $table->timestamps();


### PR DESCRIPTION
Change field type to 'text' to increase allowed length.

Fails with 'string' type when using Laravel Socialite
to login to Facebook which returns a string which
is > 400 characters. Changing to 'text' field type
allows more than the 'string' type 255 charachters.

<img width="411" alt="screen shot 2017-09-13 at 07 04 05" src="https://user-images.githubusercontent.com/1869424/30362234-01456a2a-9853-11e7-9dda-55e99210cf25.png">