### PR TITLE
Update the Auditable Events definition

### DIFF
--- a/tests/Stubs/AuditableStub.php
+++ b/tests/Stubs/AuditableStub.php
@@ -56,4 +56,12 @@ class AuditableStub extends Model implements AuditableContract
     {
         return strtoupper($value);
     }
+
+    protected function auditCustomAttributes(array &$old, array &$new)
+    {
+    }
+
+    protected function myAttributesMethod(array &$old, array &$new)
+    {
+    }
 }


### PR DESCRIPTION
Auditable Events can now have `*` in their names and can define a custom attributes method.