### PR TITLE
Use Model's $dateFormat for formatting data

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -142,7 +142,7 @@ trait Audit
 
         // Honour DateTime attribute
         if ($value !== null && in_array($key, $model->getDates(), true)) {
-            return $this->asDateTime($value);
+            return $model->asDateTime($value);
         }
 
         return $value;


### PR DESCRIPTION
When the Model uses a different $dateFormat than Audit, Carbon throws an exception. Calling $model->asDateTime() allows the model's $dateFormat to be used.

I just started with Laravel Auditing, apologies if I'm misunderstanding this method.