### PR TITLE
[FIX] Issue 418 - Audit presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v6.1.1 (2018-04-27)
+
+### Fixed
+- Audit presentation issue when using `trans()` or `@lang()` ([#418](https://github.com/owen-it/laravel-auditing/issues/418))
+
 ## v6.1.0 (2018-04-23)
 ### Added
 - Audit redactor feature ([#395](https://github.com/owen-it/laravel-auditing/issues/395))

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -224,8 +224,8 @@ trait Audit
      *
      * @return array
      */
-    public function getTagsAttribute(): array
+    public function getTags(): array
     {
-        return preg_split('/,/', $this->attributes['tags'], null, PREG_SPLIT_NO_EMPTY);
+        return preg_split('/,/', $this->tags, null, PREG_SPLIT_NO_EMPTY);
     }
 }

--- a/tests/Unit/AuditTest.php
+++ b/tests/Unit/AuditTest.php
@@ -76,7 +76,7 @@ class AuditTest extends AuditingTestCase
             'audit_url'        => 'console',
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony/3.X',
-            'audit_tags'       => [],
+            'audit_tags'       => null,
             'audit_created_at' => $audit->created_at->toDateTimeString(),
             'audit_updated_at' => $audit->updated_at->toDateTimeString(),
             'user_id'          => null,
@@ -122,7 +122,7 @@ class AuditTest extends AuditingTestCase
             'audit_url'        => 'console',
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony/3.X',
-            'audit_tags'       => [],
+            'audit_tags'       => null,
             'audit_created_at' => $audit->created_at->toDateTimeString(),
             'audit_updated_at' => $audit->updated_at->toDateTimeString(),
             'user_id'          => '1',
@@ -202,7 +202,7 @@ class AuditTest extends AuditingTestCase
             'audit_url'        => 'console',
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony/3.X',
-            'audit_tags'       => [],
+            'audit_tags'       => null,
             'audit_created_at' => $audit->created_at->toDateTimeString(),
             'audit_updated_at' => $audit->updated_at->toDateTimeString(),
             'user_id'          => null,
@@ -234,7 +234,7 @@ class AuditTest extends AuditingTestCase
             'audit_url'        => 'console',
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony/3.X',
-            'audit_tags'       => [],
+            'audit_tags'       => null,
             'audit_created_at' => $audit->created_at->toDateTimeString(),
             'audit_updated_at' => $audit->updated_at->toDateTimeString(),
             'user_id'          => 1,
@@ -264,7 +264,7 @@ class AuditTest extends AuditingTestCase
     "audit_url": "console",
     "audit_ip_address": "127.0.0.1",
     "audit_user_agent": "Symfony\/3.X",
-    "audit_tags": [],
+    "audit_tags": null,
     "audit_created_at": "$audit->created_at",
     "audit_updated_at": "$audit->updated_at",
     "user_id": null
@@ -300,7 +300,7 @@ EOF;
     "audit_url": "console",
     "audit_ip_address": "127.0.0.1",
     "audit_user_agent": "Symfony\/3.X",
-    "audit_tags": [],
+    "audit_tags": null,
     "audit_created_at": "$audit->created_at",
     "audit_updated_at": "$audit->updated_at",
     "user_id": 1,
@@ -390,5 +390,37 @@ EOF;
 EOF;
 
         $this->assertSame($expected, $modified);
+    }
+
+    /**
+     * @group Audit::getTags
+     * @test
+     */
+    public function itReturnsTags()
+    {
+        $audit = factory(Audit::class)->create([
+            'tags' => 'foo,bar,baz',
+        ]);
+
+        $this->assertInternalType('array', $audit->getTags());
+        $this->assertArraySubset([
+            'foo',
+            'bar',
+            'baz',
+        ], $audit->getTags(), true);
+    }
+
+    /**
+     * @group Audit::getTags
+     * @test
+     */
+    public function itReturnsEmptyTags()
+    {
+        $audit = factory(Audit::class)->create([
+            'tags' => null,
+        ]);
+
+        $this->assertInternalType('array', $audit->getTags());
+        $this->assertEmpty($audit->getTags());
     }
 }


### PR DESCRIPTION
This pull request fixes an issue with the Tags feature (introduced in **v5.0.0**), when using the `getMetadata()` method in the `trans()` and `@lang()` helpers, which would cause an error (see #418).

The fix does cause a minor breaking change, although it's quite straightforward to mitigate (in case you're using the tag values).

Previous calls to `$audit->tags`, which would return an array (`['foo', 'bar',]` or `[]`), now return the original string value (`foo,bar` or `null`) as stored in the database.

To get the tags as an `array`, like in versions **v5.0.0** up to **v6.1.0**, you should now use the `getTags()` method instead: `$audit->getTags()`