### PR TITLE
[FEAT] V7 - Multi user audits

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -30,14 +30,18 @@ return [
     | User Keys, Model
     |--------------------------------------------------------------------------
     |
-    | Define the User primary key, foreign key and Eloquent model.
+    | Define the User Eloquent model, morph prefix and authentication guards
+    | to use in the User resolver.
     |
     */
 
     'user' => [
-        'primary_key' => 'id',
-        'foreign_key' => 'user_id',
-        'model'       => App\User::class,
+        'model'        => App\User::class,
+        'morph_prefix' => 'user',
+        'guards'       => [
+            'web',
+            'api',
+        ],
     ],
 
     /*

--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -27,7 +27,7 @@ class CreateAuditsTable extends Migration
     {
         Schema::create('audits', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('user_id')->nullable();
+            $table->nullableMorphs('user');
             $table->string('event');
             $table->morphs('auditable');
             $table->text('old_values')->nullable();

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -16,7 +16,6 @@ namespace OwenIt\Auditing;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Config;
 
@@ -70,13 +69,9 @@ trait Audit
     /**
      * {@inheritdoc}
      */
-    public function user(): BelongsTo
+    public function user(): MorphTo
     {
-        return $this->belongsTo(
-            Config::get('audit.user.model'),
-            Config::get('audit.user.foreign_key', 'user_id'),
-            Config::get('audit.user.primary_key', 'id')
-        );
+        return $this->morphTo();
     }
 
     /**
@@ -84,6 +79,8 @@ trait Audit
      */
     public function resolveData(): array
     {
+        $morphPrefix = Config::get('audit.user.morph_prefix', 'user');
+
         // Metadata
         $this->data = [
             'audit_id'         => $this->id,
@@ -94,7 +91,8 @@ trait Audit
             'audit_tags'       => $this->tags,
             'audit_created_at' => $this->serializeDate($this->created_at),
             'audit_updated_at' => $this->serializeDate($this->updated_at),
-            'user_id'          => $this->getAttribute(Config::get('audit.user.foreign_key', 'user_id')),
+            'user_id'          => $this->getAttribute($morphPrefix.'_id'),
+            'user_type'        => $this->getAttribute($morphPrefix.'_type'),
         ];
 
         if ($this->user) {

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -278,21 +278,24 @@ trait Auditable
             }
         }
 
-        $userForeignKey = Config::get('audit.user.foreign_key', 'user_id');
+        $morphPrefix = Config::get('audit.user.morph_prefix', 'user');
 
         $tags = implode(',', $this->generateTags());
 
+        $user = $this->resolveUser();
+
         return $this->transformAudit([
-            'old_values'     => $old,
-            'new_values'     => $new,
-            'event'          => $this->auditEvent,
-            'auditable_id'   => $this->getKey(),
-            'auditable_type' => $this->getMorphClass(),
-            $userForeignKey  => $this->resolveUser(),
-            'url'            => $this->resolveUrl(),
-            'ip_address'     => $this->resolveIpAddress(),
-            'user_agent'     => $this->resolveUserAgent(),
-            'tags'           => empty($tags) ? null : $tags,
+            'old_values'         => $old,
+            'new_values'         => $new,
+            'event'              => $this->auditEvent,
+            'auditable_id'       => $this->getKey(),
+            'auditable_type'     => $this->getMorphClass(),
+            $morphPrefix.'_id'   => $user ? $user->getAuthIdentifier() : null,
+            $morphPrefix.'_type' => $user ? $user->getMorphClass() : null,
+            'url'                => $this->resolveUrl(),
+            'ip_address'         => $this->resolveIpAddress(),
+            'user_agent'         => $this->resolveUserAgent(),
+            'tags'               => empty($tags) ? null : $tags,
         ]);
     }
 

--- a/src/Contracts/Audit.php
+++ b/src/Contracts/Audit.php
@@ -14,7 +14,6 @@
 
 namespace OwenIt\Auditing\Contracts;
 
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 interface Audit
@@ -43,9 +42,9 @@ interface Audit
     /**
      * User responsible for the changes.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function user(): BelongsTo;
+    public function user(): MorphTo;
 
     /**
      * Audit data resolver.

--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -34,7 +34,5 @@ class UserResolver implements \OwenIt\Auditing\Contracts\UserResolver
                 return Auth::guard($guard)->user();
             }
         }
-
-        return null;
     }
 }

--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -15,6 +15,7 @@
 namespace OwenIt\Auditing\Resolvers;
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
 
 class UserResolver implements \OwenIt\Auditing\Contracts\UserResolver
 {
@@ -23,6 +24,17 @@ class UserResolver implements \OwenIt\Auditing\Contracts\UserResolver
      */
     public static function resolve()
     {
-        return Auth::check() ? Auth::user()->getAuthIdentifier() : null;
+        $guards = Config::get('audit.user.guards', [
+            'web',
+            'api',
+        ]);
+
+        foreach ($guards as $guard) {
+            if (Auth::guard($guard)->check()) {
+                return Auth::guard($guard)->user();
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Unit/AuditableObserverTest.php
+++ b/tests/Unit/AuditableObserverTest.php
@@ -41,7 +41,7 @@ class AuditableObserverTest extends AuditingTestCase
 
         $this->assertSame($expectedBefore, $observer::$restoring);
 
-        call_user_func([$observer, $eventMethod], $model);
+        $observer->$eventMethod($model);
 
         $this->assertSame($expectedAfter, $observer::$restoring);
     }

--- a/tests/Unit/AuditableObserverTest.php
+++ b/tests/Unit/AuditableObserverTest.php
@@ -49,7 +49,7 @@ class AuditableObserverTest extends AuditingTestCase
     /**
      * @return array
      */
-    public function auditableObserverTestProvider()
+    public function auditableObserverTestProvider(): array
     {
         return [
             [

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -260,7 +260,7 @@ class AuditableTest extends AuditingTestCase
     /**
      * @return array
      */
-    public function auditCustomAttributeGetterFailTestProvider()
+    public function auditCustomAttributeGetterFailTestProvider(): array
     {
         return [
             [
@@ -388,7 +388,7 @@ class AuditableTest extends AuditingTestCase
 
         $model->setAuditEvent('created');
 
-        $this->assertCount(10, $auditData = $model->toAudit());
+        $this->assertCount(11, $auditData = $model->toAudit());
 
         $this->assertArraySubset([
             'old_values' => [],
@@ -402,6 +402,7 @@ class AuditableTest extends AuditingTestCase
             'auditable_id'   => null,
             'auditable_type' => Article::class,
             'user_id'        => null,
+            'user_type'      => null,
             'url'            => 'console',
             'ip_address'     => '127.0.0.1',
             'user_agent'     => 'Symfony/3.X',
@@ -413,12 +414,27 @@ class AuditableTest extends AuditingTestCase
      * @group Auditable::setAuditEvent
      * @group Auditable::toAudit
      * @test
+     *
+     * @dataProvider userResolverProvider
+     *
+     * @param string $guard
+     * @param string $driver
+     * @param int    $id
+     * @param string $type
      */
-    public function itReturnsTheAuditDataIncludingUserAttributes()
-    {
+    public function itReturnsTheAuditDataIncludingUserAttributes(
+        string $guard,
+        string $driver,
+        int $id = null,
+        string $type = null
+    ) {
+        $this->app['config']->set('audit.user.guards', [
+            $guard,
+        ]);
+
         $user = factory(User::class)->create();
 
-        $this->actingAs($user);
+        $this->actingAs($user, $driver);
 
         $now = Carbon::now();
 
@@ -431,7 +447,7 @@ class AuditableTest extends AuditingTestCase
 
         $model->setAuditEvent('created');
 
-        $this->assertCount(10, $auditData = $model->toAudit());
+        $this->assertCount(11, $auditData = $model->toAudit());
 
         $this->assertArraySubset([
             'old_values' => [],
@@ -444,12 +460,46 @@ class AuditableTest extends AuditingTestCase
             'event'          => 'created',
             'auditable_id'   => null,
             'auditable_type' => Article::class,
-            'user_id'        => 1,
+            'user_id'        => $id,
+            'user_type'      => $type,
             'url'            => 'console',
             'ip_address'     => '127.0.0.1',
             'user_agent'     => 'Symfony/3.X',
             'tags'           => null,
         ], $auditData, true);
+    }
+
+    /**
+     * @return array
+     */
+    public function userResolverProvider(): array
+    {
+        return [
+            [
+                'api',
+                'web',
+                null,
+                null,
+            ],
+            [
+                'web',
+                'api',
+                null,
+                null,
+            ],
+            [
+                'api',
+                'api',
+                1,
+                User::class,
+            ],
+            [
+                'web',
+                'web',
+                1,
+                User::class,
+            ],
+        ];
     }
 
     /**
@@ -479,7 +529,7 @@ class AuditableTest extends AuditingTestCase
 
         $model->setAuditEvent('created');
 
-        $this->assertCount(10, $auditData = $model->toAudit());
+        $this->assertCount(11, $auditData = $model->toAudit());
 
         $this->assertArraySubset([
             'old_values' => [],
@@ -491,6 +541,7 @@ class AuditableTest extends AuditingTestCase
             'auditable_id'   => null,
             'auditable_type' => Article::class,
             'user_id'        => null,
+            'user_type'      => null,
             'url'            => 'console',
             'ip_address'     => '127.0.0.1',
             'user_agent'     => 'Symfony/3.X',
@@ -587,7 +638,7 @@ class AuditableTest extends AuditingTestCase
 
         $model->setAuditEvent('created');
 
-        $this->assertCount(10, $auditData = $model->toAudit());
+        $this->assertCount(11, $auditData = $model->toAudit());
 
         $this->assertArraySubset([
             'new_values' => [
@@ -1004,7 +1055,7 @@ class AuditableTest extends AuditingTestCase
     /**
      * @return array
      */
-    public function auditableTransitionTestProvider()
+    public function auditableTransitionTestProvider(): array
     {
         return [
             //

--- a/tests/database/factories/AuditFactory.php
+++ b/tests/database/factories/AuditFactory.php
@@ -28,6 +28,7 @@ $factory->define(Audit::class, function (Faker $faker) {
         'user_id' => function () {
             return factory(User::class)->create()->id;
         },
+        'user_type'    => User::class,
         'event'        => 'updated',
         'auditable_id' => function () {
             return factory(Article::class)->create()->id;

--- a/tests/database/migrations/0000_00_00_000001_create_audits_test_table.php
+++ b/tests/database/migrations/0000_00_00_000001_create_audits_test_table.php
@@ -26,7 +26,7 @@ class CreateAuditsTestTable extends Migration
     {
         Schema::create('audits', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('user_id')->nullable();
+            $table->nullableMorphs('user');
             $table->string('event');
             $table->morphs('auditable');
             $table->text('old_values')->nullable();


### PR DESCRIPTION
### Description
The code in this pull request is based on #420 but with a few simplifications.

**Work done:**
- [X] Audits are now related to Users via `MorphTo`;
- [X] UserResolver now checks multiple guards to resolve Users;
- [X] Updated migration with new `user_type` column;
- [X] Updated Audit factory;
- [X] Updated tests;
- [X] Other minor cleanups;

Special thanks to [Webparking](https://github.com/Webparking) for their initial work!

@crashkonijn & @remkobrenters