### PR TITLE
Add availability to nonScalar for recursive Array and noSQL usage

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -23,7 +23,7 @@ return [
     |
     */
 
-    'implementation' => App\Models\Audit::class,
+    'implementation' => OwenIt\Auditing\Models\Audit::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -105,7 +105,7 @@ return [
     |
     */
 
-    'threshold' => 100,
+    'threshold' => 0,
 
     /*
     |--------------------------------------------------------------------------
@@ -141,7 +141,7 @@ return [
     'drivers' => [
         'database' => [
             'table'      => 'audits',
-            'connection' => 'mongodb',
+            'connection' => null,
         ],
     ],
 

--- a/config/audit.php
+++ b/config/audit.php
@@ -23,7 +23,7 @@ return [
     |
     */
 
-    'implementation' => OwenIt\Auditing\Models\Audit::class,
+    'implementation' => App\Models\Audit::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -36,7 +36,7 @@ return [
 
     'user' => [
         'morph_prefix' => 'user',
-        'guards'       => [
+        'guards' => [
             'web',
             'api',
         ],
@@ -51,10 +51,10 @@ return [
     |
     */
     'resolver' => [
-        'user'       => OwenIt\Auditing\Resolvers\UserResolver::class,
+        'user' => OwenIt\Auditing\Resolvers\UserResolver::class,
         'ip_address' => OwenIt\Auditing\Resolvers\IpAddressResolver::class,
         'user_agent' => OwenIt\Auditing\Resolvers\UserAgentResolver::class,
-        'url'        => OwenIt\Auditing\Resolvers\UrlResolver::class,
+        'url' => OwenIt\Auditing\Resolvers\UrlResolver::class,
     ],
 
     /*
@@ -105,7 +105,7 @@ return [
     |
     */
 
-    'threshold' => 0,
+    'threshold' => 100,
 
     /*
     |--------------------------------------------------------------------------
@@ -140,8 +140,8 @@ return [
 
     'drivers' => [
         'database' => [
-            'table'      => 'audits',
-            'connection' => null,
+            'table' => 'audits',
+            'connection' => 'mongodb',
         ],
     ],
 
@@ -155,7 +155,7 @@ return [
     */
 
     'console' => false,
-    
+
     /*
     |--------------------------------------------------------------------------
     | Audit Allow Saving NonScalar Values and Recursive Arrays
@@ -164,6 +164,7 @@ return [
     | Allow Saving NonScalar Values and Recursive Arrays
     |
     */
-    
-    'nonScalar' => false,
+
+    'nonScalar' => true,
+
 ];

--- a/config/audit.php
+++ b/config/audit.php
@@ -36,7 +36,7 @@ return [
 
     'user' => [
         'morph_prefix' => 'user',
-        'guards' => [
+        'guards'       => [
             'web',
             'api',
         ],
@@ -51,10 +51,10 @@ return [
     |
     */
     'resolver' => [
-        'user' => OwenIt\Auditing\Resolvers\UserResolver::class,
+        'user'       => OwenIt\Auditing\Resolvers\UserResolver::class,
         'ip_address' => OwenIt\Auditing\Resolvers\IpAddressResolver::class,
         'user_agent' => OwenIt\Auditing\Resolvers\UserAgentResolver::class,
-        'url' => OwenIt\Auditing\Resolvers\UrlResolver::class,
+        'url'        => OwenIt\Auditing\Resolvers\UrlResolver::class,
     ],
 
     /*
@@ -140,7 +140,7 @@ return [
 
     'drivers' => [
         'database' => [
-            'table' => 'audits',
+            'table'      => 'audits',
             'connection' => 'mongodb',
         ],
     ],
@@ -165,6 +165,5 @@ return [
     |
     */
 
-    'nonScalar' => true,
-
+    'nonScalar' => false,
 ];

--- a/config/audit.php
+++ b/config/audit.php
@@ -164,6 +164,6 @@ return [
     | Allow Saving NonScalar Values and Recursive Arrays
     |
     */
-
+    
     'nonScalar' => false,
 ];

--- a/config/audit.php
+++ b/config/audit.php
@@ -155,4 +155,15 @@ return [
     */
 
     'console' => false,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Audit Allow Saving NonScalar Values and Recursive Arrays
+    |--------------------------------------------------------------------------
+    |
+    | Allow Saving NonScalar Values and Recursive Arrays
+    |
+    */
+
+    'nonScalar' => false,
 ];

--- a/config/audit.php
+++ b/config/audit.php
@@ -165,5 +165,5 @@ return [
     |
     */
 
-    'nonScalar' => false,
+    'non_scalar' => false,
 ];

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -103,13 +103,15 @@ trait Auditable
             }
         }
 
-        // Valid attributes are all those that made it out of the exclusion array
-        $attributes = array_except($this->attributes, $this->excludedAttributes);
+        if (!Config::get('audit.nonScalar', false)) {
+            // Valid attributes are all those that made it out of the exclusion array
+            $attributes = array_except($this->attributes, $this->excludedAttributes);
 
-        foreach ($attributes as $attribute => $value) {
-            // Apart from null, non scalar values will be excluded
-            if (is_array($value) || (is_object($value) && !method_exists($value, '__toString'))) {
-                $this->excludedAttributes[] = $attribute;
+            foreach ($attributes as $attribute => $value) {
+                // Apart from null, non scalar values will be excluded
+                if (\is_array($value) || (\is_object($value) && !method_exists($value, '__toString'))) {
+                    $this->excludedAttributes[] = $attribute;
+                }
             }
         }
     }

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -109,7 +109,7 @@ trait Auditable
 
             foreach ($attributes as $attribute => $value) {
                 // Apart from null, non scalar values will be excluded
-                if (\is_array($value) || (\is_object($value) && !method_exists($value, '__toString'))) {
+                if (is_array($value) || (is_object($value) && !method_exists($value, '__toString'))) {
                     $this->excludedAttributes[] = $attribute;
                 }
             }

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -103,7 +103,7 @@ trait Auditable
             }
         }
 
-        if (!Config::get('audit.nonScalar', false)) {
+        if (!Config::get('audit.non_scalar', false)) {
             // Valid attributes are all those that made it out of the exclusion array
             $attributes = array_except($this->attributes, $this->excludedAttributes);
 


### PR DESCRIPTION
If you are using NoSQL you need this. Because noSQL has ability to recursive array or objects and you can save them but in this package its returning null always changes. With this change you can enable it from config. Thanks.

`{
"id":"1",
"name": "test",
"surname": "user",
"settings": {
"hasCar": true,
"hasBike": false,
"isParent": false,
},
"isActive":true
}`

In this json example when i change settings object now this package not check changes. but with my changes if anybody wanna use this only enable it from settings.