### PR TITLE
[FEAT] Make Auditable/User relation more flexible

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -16,7 +16,6 @@ namespace OwenIt\Auditing;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Config;
 use OwenIt\Auditing\Contracts\AttributeEncoder;
 
@@ -57,22 +56,6 @@ trait Audit
     public function getTable(): string
     {
         return Config::get('audit.drivers.database.table', parent::getTable());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function auditable(): MorphTo
-    {
-        return $this->morphTo();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function user(): MorphTo
-    {
-        return $this->morphTo();
     }
 
     /**

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -15,6 +15,7 @@
 namespace OwenIt\Auditing\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Audit extends Model implements \OwenIt\Auditing\Contracts\Audit
 {
@@ -33,4 +34,20 @@ class Audit extends Model implements \OwenIt\Auditing\Contracts\Audit
         'new_values'    => 'json',
         'auditable_id'  => 'integer',
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function user(): MorphTo
+    {
+        return $this->morphTo();
+    }
 }


### PR DESCRIPTION
This PR moves the Auditable/User morph relations from the trait to the model, making it easier to customise the relationship.

Issue was brought up in #450 