### PR TITLE
Increase size of user_agent column

### DIFF
--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -23,7 +23,7 @@ class CreateAuditsTable extends Migration
             $table->text('new_values')->nullable();
             $table->text('url')->nullable();
             $table->ipAddress('ip_address')->nullable();
-            $table->string('user_agent')->nullable();
+            $table->string('user_agent', 2048)->nullable();
             $table->string('tags')->nullable();
             $table->timestamps();
 			


### PR DESCRIPTION
If a user_agent string is is longer than the Laravel default value of the string field, inserting the audit causes an exception which in turn breaks the application. Changing the user_agent string to always be 2048 characters will solve this issue. While there is no limit on the size of a user agent string, somewhere between 512 - 2048 seems to be the recommended max size.