### PR TITLE
Request to fix #466

### DIFF
--- a/src/AuditingServiceProvider.php
+++ b/src/AuditingServiceProvider.php
@@ -5,6 +5,10 @@ namespace OwenIt\Auditing;
 use Illuminate\Support\ServiceProvider;
 use OwenIt\Auditing\Console\AuditDriverMakeCommand;
 use OwenIt\Auditing\Contracts\Auditor;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RecursiveRegexIterator;
+
 
 class AuditingServiceProvider extends ServiceProvider
 {
@@ -29,11 +33,30 @@ class AuditingServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            $migration => database_path(sprintf('migrations/%s_create_audits_table.php', date('Y_m_d_His'))),
+            $migration => database_path('migrations/'.$this->deprecatedFileName()),
         ], 'migrations');
 
         $this->mergeConfigFrom($config, 'audit');
     }
+
+    /**
+     * Check to see if package has been used previously.
+     * If it has, use that file name, if not, use a file name that timestamps the day of this pull request
+     * @return string
+     */
+    protected function deprecatedFileName()
+    {
+        $iterator = iterator_to_array(new RecursiveIteratorIterator(
+            new RecursiveRegexIterator(
+                new RecursiveDirectoryIterator(database_path('migrations'), RecursiveDirectoryIterator::KEY_AS_PATHNAME|RecursiveDirectoryIterator::SKIP_DOTS),
+                '/(\d{4})_(\d{2})_(\d{2})_(\d{6})_create_audits_table\.php/i', RecursiveRegexIterator::MATCH
+            ),
+            RecursiveIteratorIterator::SELF_FIRST
+        ));
+
+        return count($iterator) ? reset($iterator)->getFilename() : '2018_11_22_000000_create_audits_table.php';
+    }
+
 
     /**
      * Register the service provider.


### PR DESCRIPTION
Use the current filename if migration exists, if not, use a static filename from now on.