### PR TITLE
Update UrlResolver to use Request::fullUrl()

### DIFF
--- a/src/Resolvers/UrlResolver.php
+++ b/src/Resolvers/UrlResolver.php
@@ -16,6 +16,6 @@ class UrlResolver implements \OwenIt\Auditing\Contracts\UrlResolver
             return 'console';
         }
 
-        return Request::fullUrlWithQuery([]);
+        return Request::fullUrl();
     }
 }


### PR DESCRIPTION
Prevents trailing question marks in Audit URLs. Fixes #471.