### PR TITLE
Added audit.enabled config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /vendor
 composer.lock
+.vscode

--- a/config/audit.php
+++ b/config/audit.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'enabled' => env('AUDITING_ENABLED', true),
+
     /*
     |--------------------------------------------------------------------------
     | Audit Implementation

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -283,8 +283,8 @@ trait Auditable
             'event'              => $this->auditEvent,
             'auditable_id'       => $this->getKey(),
             'auditable_type'     => $this->getMorphClass(),
-            $morphPrefix.'_id'   => $user ? $user->getAuthIdentifier() : null,
-            $morphPrefix.'_type' => $user ? $user->getMorphClass() : null,
+            $morphPrefix . '_id'   => $user ? $user->getAuthIdentifier() : null,
+            $morphPrefix . '_type' => $user ? $user->getMorphClass() : null,
             'url'                => $this->resolveUrl(),
             'ip_address'         => $this->resolveIpAddress(),
             'user_agent'         => $this->resolveUserAgent(),
@@ -487,7 +487,7 @@ trait Auditable
             return Config::get('audit.console', false);
         }
 
-        return true;
+        return Config::get('audit.enabled', true);
     }
 
     /**


### PR DESCRIPTION
This allows disabling auditing globally using the config:
`'enabled' => env('AUDITING_ENABLED', true),`

It "fixes" https://github.com/owen-it/laravel-auditing/issues/435

I decided to implement it because I'm using a custom driver that sends notifications through AWS SNS, so I need to disable auditing locally.