### PR TITLE
Removed a blank line of tabs from migration stub

### DIFF
--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -26,7 +26,7 @@ class CreateAuditsTable extends Migration
             $table->string('user_agent', 1023)->nullable();
             $table->string('tags')->nullable();
             $table->timestamps();
-			
+
             $table->index(['user_id', 'user_type']);
         });
     }


### PR DESCRIPTION
Weren't having any functional effect, just making my eye twitch when editing the *audits* table migration.