### PR TITLE
Allow dynamically setting audit tags

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -550,9 +550,9 @@ trait Auditable
     /**
      * {@inheritdoc}
      */
-    public function generateTags(): array
+    public function generateTags(array $tags = []): array
     {
-        return [];
+        return $tags;
     }
 
     /**

--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -113,9 +113,11 @@ interface Auditable
     /**
      * Generate an array with the model tags.
      *
+     * @param array $tags
+     * 
      * @return array
      */
-    public function generateTags(): array;
+    public function generateTags(array $tags = []): array;
 
     /**
      * Transition to another model state from an Audit.


### PR DESCRIPTION
This pull request aims to make setting your audit tags dynamically much easier.

Prior to this request, a user would be required to take extra steps to set their audit tags if they wanted to do so dynamically. A property (`dynamicAuditTags`) would need to be set to hold the array of tags, and on each model the `generateTags` would need to have code written to check if the dynamic audit tags property is empty and insert them if it isn't. E.g.

**Old, excessive way:**

	public $dynamicAuditTags = [];

	/**
	 * {@inheritdoc}
	 */
	public function generateTags(): array
	{
		return empty($this->dynamicAuditTags) ?
		[
			$this->editor->name,
			$this->reporter->name,
			$this->designer->name,
			$this->photographer->name,
		] : $this->dynamicAuditTags;
	}



	// in some controller

	$model->dynamicAuditTags = ['bulk_operation'];
	$model->update($data);

This PR makes things much simpler.

	// in some controller

	$model->generateTags(['bulk_operation']);
	$model->update($data);

You wouldn't even need to define ``generateTags`` on the model. The trait would automatically handle this behavior. And if users wanted to define static tags on every model they still could.

The methodology of this approach favors programatic handling over static handling. The advantage is users having to overwrite the ``generateTags`` method less often.