### PR TITLE
[FIX] Substitute str_replace_last with the respective Str helper 

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -43,7 +43,7 @@ class InstallCommand extends Command
      */
     protected function registerAuditingServiceProvider()
     {
-        $namespace = str_replace_last('\\', '', $this->getAppNamespace());
+        $namespace = Str::replace_last('\\', '', $this->getAppNamespace());
 
         $appConfig = file_get_contents(config_path('app.php'));
 


### PR DESCRIPTION
to remove the seemingly last occurence of the now obsolete str_* methods and with that the dependency on laravel/helpers package

as mentioned at https://github.com/owen-it/laravel-auditing/pull/545