### PR TITLE
Miss dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^3.8",
+        "ext-sqlite3": "*",
         "ramsey/uuid": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Sqlite3 e extension is required to run tests. Is interesting explicit require them in dev mode

sqlite3 is used here
https://github.com/owen-it/laravel-auditing/blob/master/tests/AuditingTestCase.php#L22