### PR TITLE
Add support for Laravel 7

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,7 +4,6 @@ risky: true
 
 enabled:
   - php_unit_strict
-  - return_type_declaration
 
 disabled:
   - self_accessor

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,9 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/console": "^5.8|^6.0",
-        "illuminate/database": "^5.8|^6.0",
-        "illuminate/filesystem": "^5.8|^6.0"
+        "illuminate/console": "^5.8|^6.0|^7.0",
+        "illuminate/database": "^5.8|^6.0|^7.0",
+        "illuminate/filesystem": "^5.8|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,13 +3,11 @@
 namespace OwenIt\Auditing\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Console\DetectsApplicationNamespace;
+use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 
 class InstallCommand extends Command
 {
-    use DetectsApplicationNamespace;
-
     /**
      * {@inheritdoc}
      */
@@ -43,7 +41,7 @@ class InstallCommand extends Command
      */
     protected function registerAuditingServiceProvider()
     {
-        $namespace = Str::replaceLast('\\', '', $this->getAppNamespace());
+        $namespace = Str::replaceLast('\\', '', Container::getInstance()->getNamespace());
 
         $appConfig = file_get_contents(config_path('app.php'));
 

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -3,6 +3,7 @@
 namespace OwenIt\Auditing\Tests\Functional;
 
 use Carbon\Carbon;
+use Illuminate\Foundation\Testing\Assert;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use InvalidArgumentException;
@@ -142,7 +143,7 @@ class AuditingTest extends AuditingTestCase
 
         $this->assertEmpty($audit->old_values);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'title'        => 'How To Audit Eloquent Models',
             'content'      => 'N/A',
             'published_at' => null,
@@ -177,13 +178,13 @@ class AuditingTest extends AuditingTestCase
 
         $audit = Audit::first();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'content'      => 'N/A',
             'published_at' => null,
             'reviewed'     => 0,
         ], $audit->old_values, true);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'content'      => 'First step: install the laravel-auditing package.',
             'published_at' => $now->toDateTimeString(),
             'reviewed'     => 1,
@@ -210,7 +211,7 @@ class AuditingTest extends AuditingTestCase
 
         $audit = Audit::first();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'title'        => 'How To Audit Eloquent Models',
             'content'      => 'N/A',
             'published_at' => null,
@@ -244,7 +245,7 @@ class AuditingTest extends AuditingTestCase
 
         $this->assertEmpty($audit->old_values);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'title'        => 'How To Audit Eloquent Models',
             'content'      => 'N/A',
             'published_at' => null,
@@ -344,7 +345,7 @@ class AuditingTest extends AuditingTestCase
 
         $this->assertEmpty($audit->old_values);
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'title'        => 'How To Audit Using The Fallback Driver',
             'content'      => 'N/A',
             'published_at' => null,

--- a/tests/Unit/AuditTest.php
+++ b/tests/Unit/AuditTest.php
@@ -4,6 +4,7 @@ namespace OwenIt\Auditing\Tests;
 
 use Carbon\Carbon;
 use DateTimeInterface;
+use Illuminate\Foundation\Testing\Assert;
 use OwenIt\Auditing\Encoders\Base64Encoder;
 use OwenIt\Auditing\Models\Audit;
 use OwenIt\Auditing\Redactors\LeftRedactor;
@@ -31,7 +32,7 @@ class AuditTest extends AuditingTestCase
 
         $this->assertCount(15, $resolvedData = $audit->resolveData());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'audit_id'         => 1,
             'audit_event'      => 'created',
             'audit_url'        => 'console',
@@ -78,7 +79,7 @@ class AuditTest extends AuditingTestCase
 
         $this->assertCount(21, $resolvedData = $audit->resolveData());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'audit_id'         => 2,
             'audit_event'      => 'created',
             'audit_url'        => 'console',
@@ -159,7 +160,7 @@ class AuditTest extends AuditingTestCase
 
         $this->assertCount(10, $metadata = $audit->getMetadata());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'audit_id'         => 1,
             'audit_event'      => 'created',
             'audit_url'        => 'console',
@@ -192,7 +193,7 @@ class AuditTest extends AuditingTestCase
 
         $this->assertCount(16, $metadata = $audit->getMetadata());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'audit_id'         => 2,
             'audit_event'      => 'created',
             'audit_url'        => 'console',
@@ -300,7 +301,7 @@ EOF;
 
         $this->assertCount(5, $modified = $audit->getModified());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'title' => [
                 'new' => 'HOW TO AUDIT ELOQUENT MODELS',
             ],
@@ -391,7 +392,7 @@ EOF;
 
         $this->assertCount(3, $modified = $audit->getModified());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'title' => [
                 'new' => 'HOW TO AUDIT ELOQUENT MODELS',
                 'old' => 'HOW TO AUDIT MODELS',
@@ -417,8 +418,8 @@ EOF;
             'tags' => 'foo,bar,baz',
         ]);
 
-        $this->assertInternalType('array', $audit->getTags());
-        $this->assertArraySubset([
+        $this->assertIsArray($audit->getTags());
+        Assert::assertArraySubset([
             'foo',
             'bar',
             'baz',
@@ -435,7 +436,7 @@ EOF;
             'tags' => null,
         ]);
 
-        $this->assertInternalType('array', $audit->getTags());
+        $this->assertIsArray($audit->getTags());
         $this->assertEmpty($audit->getTags());
     }
 }

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -4,6 +4,7 @@ namespace OwenIt\Auditing\Tests;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Foundation\Testing\Assert;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use OwenIt\Auditing\Contracts\Auditable;
@@ -115,7 +116,7 @@ class AuditableTest extends AuditingTestCase
     {
         $model = new Article();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'created',
             'updated',
             'deleted',
@@ -136,7 +137,7 @@ class AuditableTest extends AuditingTestCase
             'archived',
         ];
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'published' => 'getPublishedEventAttributes',
             'archived',
         ], $model->getAuditEvents(), true);
@@ -155,7 +156,7 @@ class AuditableTest extends AuditingTestCase
 
         $model = new Article();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'published' => 'getPublishedEventAttributes',
             'archived',
         ], $model->getAuditEvents(), true);
@@ -399,7 +400,7 @@ class AuditableTest extends AuditingTestCase
 
         $this->assertCount(11, $auditData = $model->toAudit());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'old_values' => [],
             'new_values' => [
                 'title'        => 'How To Audit Eloquent Models',
@@ -458,7 +459,7 @@ class AuditableTest extends AuditingTestCase
 
         $this->assertCount(11, $auditData = $model->toAudit());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'old_values' => [],
             'new_values' => [
                 'title'        => 'How To Audit Eloquent Models',
@@ -540,7 +541,7 @@ class AuditableTest extends AuditingTestCase
 
         $this->assertCount(11, $auditData = $model->toAudit());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'old_values' => [],
             'new_values' => [
                 'title'   => 'How To Audit Eloquent Models',
@@ -610,7 +611,7 @@ class AuditableTest extends AuditingTestCase
             'reviewed' => Base64Encoder::class,
         ];
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'old_values' => [
                 'title'        => 'Ho#################',
                 'content'      => '##A',
@@ -654,7 +655,7 @@ class AuditableTest extends AuditingTestCase
 
         $this->assertCount(11, $auditData = $model->toAudit());
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'new_values' => [
                 'title'        => 'How To Audit Eloquent Models',
                 'content'      => 'First step: install the laravel-auditing package.',
@@ -673,7 +674,7 @@ class AuditableTest extends AuditingTestCase
     {
         $model = new Article();
 
-        $this->assertArraySubset([], $model->getAuditInclude(), true);
+        Assert::assertArraySubset([], $model->getAuditInclude(), true);
     }
 
     /**
@@ -689,7 +690,7 @@ class AuditableTest extends AuditingTestCase
             'content',
         ];
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'title',
             'content',
         ], $model->getAuditInclude(), true);
@@ -703,7 +704,7 @@ class AuditableTest extends AuditingTestCase
     {
         $model = new Article();
 
-        $this->assertArraySubset([], $model->getAuditExclude(), true);
+        Assert::assertArraySubset([], $model->getAuditExclude(), true);
     }
 
     /**
@@ -718,7 +719,7 @@ class AuditableTest extends AuditingTestCase
             'published_at',
         ];
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'published_at',
         ], $model->getAuditExclude(), true);
     }
@@ -879,7 +880,7 @@ class AuditableTest extends AuditingTestCase
     {
         $model = new Article();
 
-        $this->assertArraySubset([], $model->generateTags(), true);
+        Assert::assertArraySubset([], $model->generateTags(), true);
     }
 
     /**
@@ -898,7 +899,7 @@ class AuditableTest extends AuditingTestCase
             }
         };
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'foo',
             'bar',
         ], $model->generateTags(), true);
@@ -1061,7 +1062,7 @@ class AuditableTest extends AuditingTestCase
                 $e->getMessage()
             );
 
-            $this->assertArraySubset([
+            Assert::assertArraySubset([
                 'subject',
                 'text',
             ], $e->getIncompatibilities(), true);


### PR DESCRIPTION
## Changes

* Lifted logic from deprecated `DetectsApplicationNamespace` trait to `InstallCommand`.
* Adds `^7.0` as an installation candidate for illuminate packages
* Uses Laravel provided polyfills for deprecated phpunit assertions like `hasArraySubset`

## Testing

* [x] Successful `phpunit` test run locally
* [x] Successful usage in a Laravel 7 project (installed as a vcs repository in composer.json)