### PR TITLE
Fix: Disable audits with config even if is running on console

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,7 +4,6 @@ risky: true
 
 enabled:
   - php_unit_strict
-  - return_type_declaration
 
 disabled:
   - self_accessor

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -485,7 +485,7 @@ trait Auditable
     public static function isAuditingEnabled(): bool
     {
         if (App::runningInConsole()) {
-            return Config::get('audit.console', false);
+            return Config::get('audit.enabled', true) && Config::get('audit.console', false);
         }
 
         return Config::get('audit.enabled', true);


### PR DESCRIPTION
Sometimes we need to disable audits even running on console (for example on tests) but without this to get this behaviour we have to set the config running on console to false.

With this fix, disable audits will be disabled on all environments.