### PR TITLE
Laravel 8 Compatibility - includes php version bump, change usage of deprecated $app, updated readme and travis/scrutinizer config updated

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,7 +12,7 @@ build:
     php72:
       environment:
         php:
-          version: 7.2.5
+          version: 7.3
       tests:
         override:
           - php-scrutinizer-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 language: php
 
 php:
-    - 7.2
+    - 7.3
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The package documentation can be found on the [official website](http://www.lara
 ## Version Information
  Version   | Illuminate    | Status                  | PHP Version
 :----------|:--------------|:------------------------|:------------
- 10.x      | 5.8.x - 7.x.x | Active support :rocket: | >= 7.2.5
+ 11.x      | 5.8.x - 8.x.x | Active support :rocket: | >= 7.3
+ 10.x      | 5.8.x - 7.x.x | Active support          | >= 7.2.5
  9.x       | 5.8.x - 6.x.x | Active support          | >= 7.1.3
  8.x       | 5.2.x - 5.7.x | Active support          | >= 7.0.13
  7.x       | 5.2.x - 5.6.x | End of life             | >= 7.0.13

--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,10 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
-        "illuminate/console": "^5.8|^6.0|^7.0",
-        "illuminate/database": "^5.8|^6.0|^7.0",
-        "illuminate/filesystem": "^5.8|^6.0|^7.0"
+        "php": "^7.3",
+        "illuminate/console": "^5.8|^6.0|^7.0|^8.0",
+        "illuminate/database": "^5.8|^6.0|^7.0|^8.0",
+        "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -82,7 +82,7 @@ class Auditor extends Manager implements Contracts\Auditor
      */
     protected function createDatabaseDriver(): Database
     {
-        return $this->app->make(Database::class);
+        return $this->container->make(Database::class);
     }
 
     /**
@@ -95,7 +95,7 @@ class Auditor extends Manager implements Contracts\Auditor
      */
     protected function fireAuditingEvent(Auditable $model, AuditDriver $driver): bool
     {
-        return $this->app->make('events')->until(
+        return $this->container->make('events')->until(
             new Auditing($model, $driver)
         ) !== false;
     }

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -30,7 +30,7 @@ class Auditor extends Manager implements Contracts\Auditor
             return parent::createDriver($driver);
         } catch (InvalidArgumentException $exception) {
             if (class_exists($driver)) {
-                return $this->app->make($driver);
+                return $this->container->make($driver);
             }
 
             throw $exception;
@@ -70,7 +70,7 @@ class Auditor extends Manager implements Contracts\Auditor
             $driver->prune($model);
         }
 
-        $this->app->make('events')->dispatch(
+        $this->container->make('events')->dispatch(
             new Audited($model, $driver, $audit)
         );
     }


### PR DESCRIPTION
This PR aims to support the release of Laravel 8

The minimum php version required has been bumped to 7.3.

References to `app` has been changed to `container` in `Auditor.php`

Readme has been updated however it might not be 100% correct, let me know if I messed it up 😄  

travis php version changed to 7.3

scrutinizer php version changed to 7.3

Addresses issue #606 