### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,7 +9,7 @@ filter:
 
 build:
   nodes:
-    php72:
+    php73:
       environment:
         php:
           version: 7.3
@@ -17,7 +17,19 @@ build:
         override:
           - php-scrutinizer-run
           -
-            command: vendor/bin/phpunit --coverage-clover=coverage72
+            command: vendor/bin/phpunit --coverage-clover=coverage73
             coverage:
-              file: coverage72
+              file: coverage73
+              format: php-clover
+    php80:
+      environment:
+        php:
+          version: 8.0
+      tests:
+        override:
+          - php-scrutinizer-run
+          -
+            command: vendor/bin/phpunit --coverage-clover=coverage80
+            coverage:
+              file: coverage80
               format: php-clover

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -24,7 +24,7 @@ build:
     php80:
       environment:
         php:
-          version: 8.0
+          version: "8.0.0"
       tests:
         override:
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -29,7 +29,7 @@ build:
         override:
           - php-scrutinizer-run
           -
-            command: vendor/bin/phpunit --coverage-clover=coverage80
+            command: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover=coverage80
             coverage:
               file: coverage80
               format: php-clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: php
 
 php:
     - 7.3
+    - 8.0
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v12.0.0 (2020-12-02)
+### Added
+- PHP 8.0 support
+
+### Removed
+- Illuminate 5.8 support
+
 ## v9.0.0 (2019-03-02)
 ### Added
 - Illuminate 5.8 support

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package documentation can be found on the [official website](http://www.lara
 ## Version Information
  Version   | Illuminate    | Status                  | PHP Version
 :----------|:--------------|:------------------------|:------------
- 12.x      | 6.x.x - 8.x.x | Active support :rocket: | >= 7.3|8.0
+ 12.x      | 6.x.x - 8.x.x | Active support :rocket: | >= 7.3\|8.0
  11.x      | 5.8.x - 8.x.x | Active support          | >= 7.3
  10.x      | 5.8.x - 7.x.x | Active support          | >= 7.2.5
  9.x       | 5.8.x - 6.x.x | Active support          | >= 7.1.3

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package documentation can be found on the [official website](http://www.lara
 ## Version Information
  Version   | Illuminate    | Status                  | PHP Version
 :----------|:--------------|:------------------------|:------------
- 12.x      | 6.x.x - 8.x.x | Active support :rocket: | >= 7.3\|8.0
+ 12.x      | 6.x.x - 8.x.x | Active support :rocket: | >= 7.3 \| 8.0
  11.x      | 5.8.x - 8.x.x | Active support          | >= 7.3
  10.x      | 5.8.x - 7.x.x | Active support          | >= 7.2.5
  9.x       | 5.8.x - 6.x.x | Active support          | >= 7.1.3

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The package documentation can be found on the [official website](http://www.lara
 ## Version Information
  Version   | Illuminate    | Status                  | PHP Version
 :----------|:--------------|:------------------------|:------------
- 11.x      | 5.8.x - 8.x.x | Active support :rocket: | >= 7.3
+ 12.x      | 6.x.x - 8.x.x | Active support :rocket: | >= 7.3|8.0
+ 11.x      | 5.8.x - 8.x.x | Active support          | >= 7.3
  10.x      | 5.8.x - 7.x.x | Active support          | >= 7.2.5
  9.x       | 5.8.x - 6.x.x | Active support          | >= 7.1.3
  8.x       | 5.2.x - 5.7.x | Active support          | >= 7.0.13

--- a/composer.json
+++ b/composer.json
@@ -40,14 +40,14 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/console": "^5.8|^6.0|^7.0|^8.0",
-        "illuminate/database": "^5.8|^6.0|^7.0|^8.0",
-        "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0"
+        "illuminate/console": "^6.0|^7.0|^8.0",
+        "illuminate/database": "^6.0|^7.0|^8.0",
+        "illuminate/filesystem": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^9.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^3.8",
+        "orchestra/testbench": "^4.0",
         "ramsey/uuid": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/console": "^5.8|^6.0|^7.0|^8.0",
         "illuminate/database": "^5.8|^6.0|^7.0|^8.0",
         "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
@@ -16,9 +18,9 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
Had to drop Illuminate 5.8 support as it does not support PHP 8:
https://github.com/laravel/laravel/blob/5.8/composer.json#L11

Also, even though the tests run without problems on php 8, it looks like scrutinizer is failing to fetch php 8.0. We may need to wait for them to fix it.
```
# It tries to fetch from:
https://secure.php.net/distributions/php-8.tar.bz2

# The correct path is:
https://secure.php.net/distributions/php-8.0.0.tar.bz2
```

- Fixes #623