### PR TITLE
Correcting the observer when the model implements more Classes

### DIFF
--- a/src/AuditableObserver.php
+++ b/src/AuditableObserver.php
@@ -21,9 +21,11 @@ class AuditableObserver
      *
      * @return void
      */
-    public function retrieved(Auditable $model)
+    public function retrieved($model)
     {
-        Auditor::execute($model->setAuditEvent('retrieved'));
+        if($model instanceof Auditable){			
+            Auditor::execute($model->setAuditEvent('retrieved'));
+        }
     }
 
     /**


### PR DESCRIPTION
When the app implements more than the Audit Contract class, the observer of Audit tries to retrieve these other classes too, giving a type error. An example of a class that generates the error:
```
class Upload extends Model implements Auditable,HasMedia
{
    use \OwenIt\Auditing\Auditable;
```

To solve this I removed the type obligation of the method and add a condition to call the execute only if it is what we expect. 