### PR TITLE
Add option to prevent creating empty audit records for excluded fields

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -209,6 +209,14 @@ trait Auditable
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function shouldCreateEmptyAudits(): bool
+    {
+        return true;
+    }
+
+    /**
      * Modify attribute value.
      *
      * @param string $attribute

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -66,10 +66,14 @@ class Auditor extends Manager implements Contracts\Auditor
             return;
         }
 
-        if ($audit = $driver->audit($model)) {
-            $driver->prune($model);
+        $audit = $driver->audit($model);
+
+        if (empty($audit)) {
+            return;
         }
 
+        $driver->prune($model);
+        
         $this->container->make('events')->dispatch(
             new Audited($model, $driver, $audit)
         );

--- a/src/Contracts/AuditDriver.php
+++ b/src/Contracts/AuditDriver.php
@@ -11,7 +11,7 @@ interface AuditDriver
      *
      * @return \OwenIt\Auditing\Contracts\Audit
      */
-    public function audit(Auditable $model): Audit;
+    public function audit(Auditable $model): ?Audit;
 
     /**
      * Remove older audits that go over the threshold.

--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -44,6 +44,13 @@ interface Auditable
     public function readyForAuditing(): bool;
 
     /**
+     * Should audits be created when there are no changes?
+     * 
+     * @return bool
+     */
+    public function shouldCreateEmptyAudits(): bool;
+
+    /**
      * Return data for an Audit.
      *
      * @throws \OwenIt\Auditing\Exceptions\AuditingException

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -12,11 +12,17 @@ class Database implements AuditDriver
     /**
      * {@inheritdoc}
      */
-    public function audit(Auditable $model): Audit
+    public function audit(Auditable $model): ?Audit
     {
         $implementation = Config::get('audit.implementation', \OwenIt\Auditing\Models\Audit::class);
+        
+        $audit = $model->toAudit();
 
-        return call_user_func([$implementation, 'create'], $model->toAudit());
+        if (!$model->shouldCreateEmptyAudits() && empty($audit['new_values'])) {
+            return null;
+        }
+
+        return call_user_func([$implementation, 'create'], $audit);
     }
 
     /**

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -13,6 +13,7 @@ use OwenIt\Auditing\Models\Audit;
 use OwenIt\Auditing\Tests\AuditingTestCase;
 use OwenIt\Auditing\Tests\Models\Article;
 use OwenIt\Auditing\Tests\Models\User;
+use OwenIt\Auditing\Tests\Models\ArticleExclude;
 
 class AuditingTest extends AuditingTestCase
 {
@@ -398,5 +399,43 @@ class AuditingTest extends AuditingTestCase
 
         $this->assertSame(2, Audit::count());
         $this->assertSame(3, Article::count());
+    }
+
+    /** 
+     * @test 
+     */
+    public function itWillNotInsertAuditWhenModelShouldNotCreateEmptyAudits()
+    {
+        ArticleExclude::$shouldCreateEmptyAudits = false;
+
+        $this->assertFalse(ArticleExclude::$shouldCreateEmptyAudits);
+        
+        $article = factory(ArticleExclude::class)->create();
+
+        $this->assertSame(1, ArticleExclude::count());
+        $this->assertSame(1, Audit::count());
+
+        $article->update(['published_at' => now()]);
+
+        $this->assertSame(1, Audit::count());
+    }
+
+    /** 
+     * @test 
+     */
+    public function itWillInsertAuditWhenModelShouldCreateEmptyAudits()
+    {
+        ArticleExclude::$shouldCreateEmptyAudits = true;
+
+        $this->assertTrue(ArticleExclude::$shouldCreateEmptyAudits);
+        
+        $article = factory(ArticleExclude::class)->create();
+
+        $this->assertSame(1, ArticleExclude::count());
+        $this->assertSame(1, Audit::count());
+
+        $article->update(['published_at' => now()]);
+
+        $this->assertSame(2, Audit::count());
     }
 }

--- a/tests/Models/ArticleExclude.php
+++ b/tests/Models/ArticleExclude.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OwenIt\Auditing\Tests\Models;
+
+use OwenIt\Auditing\Contracts\Auditable;
+use OwenIt\Auditing\Tests\Models\Article;
+
+class ArticleExclude extends Article implements Auditable
+{
+    protected $table = 'articles';
+
+    public static $shouldCreateEmptyAudits = false;
+
+    public function shouldCreateEmptyAudits(): bool
+    {
+        return ArticleExclude::$shouldCreateEmptyAudits;
+    }
+    
+    protected $auditExclude = [
+        'published_at'
+    ];
+}

--- a/tests/database/factories/ArticleExcludeFactory.php
+++ b/tests/database/factories/ArticleExcludeFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+use Faker\Generator as Faker;
+use OwenIt\Auditing\Tests\Models\ArticleExclude;
+
+/*
+|--------------------------------------------------------------------------
+| ArticleExclude Factories
+|--------------------------------------------------------------------------
+|
+*/
+
+$factory->define(ArticleExclude::class, function (Faker $faker) {
+    return [
+        'title'        => $faker->unique()->sentence,
+        'content'      => $faker->unique()->paragraph(6),
+        'published_at' => null,
+        'reviewed'     => $faker->randomElement([0, 1]),
+    ];
+});


### PR DESCRIPTION
Hello 👋

This PR addresses the issue found in https://github.com/owen-it/laravel-auditing/issues/567.  

Currently, if a model has an `auditExclude` array present, and an update that changes only fields in that array happens, an empty audit record is created.

These changes add a `createEmptyAudits` property to the Auditable trait that is **true** by default.

When this is set to **false**, additional logic is run to bail on insert in the correct scenario.

