### PR TITLE
Fix PHP 8.1 deprecation message

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -415,6 +415,10 @@ trait Auditable
      */
     protected function resolveAttributeGetter($event)
     {
+        if(empty($event)) {
+            return;
+        }
+
         foreach ($this->getAuditEvents() as $key => $value) {
             $auditableEvent = is_int($key) ? $value : $key;
 


### PR DESCRIPTION
This created the deprecation message:

> PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /xyz/vendor/owen-it/laravel-auditing/src/Auditable.php on line 426

The PHPDoc says to return null but the code wouldn't have so I just put in an early return. Didn't have any problems with PHP 8.1 after that

See also #670 