### PR TITLE
add config for api guard

### DIFF
--- a/tests/AuditingTestCase.php
+++ b/tests/AuditingTestCase.php
@@ -31,6 +31,10 @@ class AuditingTestCase extends TestCase
             'web',
             'api',
         ]);
+        $app['config']->set('auth.guards.api', [
+            'driver' => 'session',
+            'provider' => 'users',
+        ]);
         $app['config']->set('audit.resolver.user', UserResolver::class);
         $app['config']->set('audit.resolver.url', UrlResolver::class);
         $app['config']->set('audit.resolver.ip_address', IpAddressResolver::class);


### PR DESCRIPTION
Should let tests run in Laravel 8