### PR TITLE
Default user guard

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -26,11 +26,8 @@ return [
 
     'user'      => [
         'morph_prefix' => 'user',
-        'guards'       => [
-            'web',
-            'api',
-        ],
-        'resolver' => OwenIt\Auditing\Resolvers\UserResolver::class
+        'guards'       => [],
+        'resolver'     => OwenIt\Auditing\Resolvers\UserResolver::class
     ],
 
     /*

--- a/config/audit.php
+++ b/config/audit.php
@@ -26,7 +26,10 @@ return [
 
     'user'      => [
         'morph_prefix' => 'user',
-        'guards'       => [],
+        'guards'       => [
+            'web',
+            'api'
+        ],
         'resolver'     => OwenIt\Auditing\Resolvers\UserResolver::class
     ],
 

--- a/src/Contracts/UserResolver.php
+++ b/src/Contracts/UserResolver.php
@@ -2,12 +2,14 @@
 
 namespace OwenIt\Auditing\Contracts;
 
+use Illuminate\Auth\Authenticatable;
+
 interface UserResolver
 {
     /**
      * Resolve the User.
      *
-     * @return mixed|null
+     * @return Authenticatable|null
      */
     public static function resolve();
 }

--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -7,17 +7,27 @@ use Illuminate\Support\Facades\Config;
 
 class UserResolver implements \OwenIt\Auditing\Contracts\UserResolver
 {
+    /**
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
     public static function resolve()
     {
         $guards = Config::get('audit.user.guards', [
-            'web',
-            'api',
+            \config('auth.defaults.guard')
         ]);
 
         foreach ($guards as $guard) {
-            if (Auth::guard($guard)->check()) {
+            try {
+                $authenticated = Auth::guard($guard);
+            } catch (\Exception $exception) {
+                continue;
+            }
+
+            if ($authenticated) {
                 return Auth::guard($guard)->user();
             }
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
Laravel Auth changed and it would be nice to change default guard. New laravel installs throws an exception from the previous default api guard, but to avoid breaking backwards we could skip unavailable guards and set a sensible default