### PR TITLE
Deprecated config causes errors

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -356,6 +356,12 @@ trait Auditable
     {
         $userResolver = Config::get('audit.user.resolver');
 
+        if (is_null($userResolver) && Config::has('audit.resolver') && !Config::has('audit.user.resolver')) {
+            trigger_error('The config file audit.php is not updated to the new version 13.0. Please see https://www.laravel-auditing.com/docs/13.0/upgrading',
+                E_USER_DEPRECATED);
+            $userResolver = Config::get('audit.resolver.user');
+        }
+
         if (is_subclass_of($userResolver, \OwenIt\Auditing\Contracts\UserResolver::class)) {
             return call_user_func([$userResolver, 'resolve']);
         }
@@ -366,6 +372,12 @@ trait Auditable
     protected function runResolvers(): array
     {
         $resolved = [];
+        if (Config::has('audit.resolver')) {
+            trigger_error('The config file audit.php is not updated to the new version 13.0. Please see https://www.laravel-auditing.com/docs/13.0/upgrading',
+                E_USER_DEPRECATED);
+            return [];
+        }
+
         foreach (Config::get('audit.resolvers', []) as $name => $implementation) {
             if (empty($implementation)) {
                 continue;


### PR DESCRIPTION
When users do not upgrade config according to documentation, audit fails with exception

We could allow for fallback to v12 config and set a deprecation notice instead of throwing exception.
relates to issue #694