### PR TITLE
`$auditEvent` from protected to public to make AuditCustom possible

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -31,7 +31,7 @@ trait Auditable
      *
      * @var string
      */
-    protected $auditEvent;
+    public $auditEvent;
 
     /**
      * Is auditing disabled?


### PR DESCRIPTION
As per this issue — https://github.com/owen-it/laravel-auditing/issues/698