### PR TITLE
Reset isCustomEvent flag after attach/detach/sync events

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -639,6 +639,7 @@ trait Auditable
             $relationName => $this->{$relationName}()->get()->isEmpty() ? [] : $this->{$relationName}()->get()->toArray()
         ];
         Event::dispatch(AuditCustom::class, [$this]);
+        $this->isCustomEvent = false;
     }
 
     /**
@@ -664,6 +665,7 @@ trait Auditable
             $relationName => $this->{$relationName}()->get()->isEmpty() ? [] : $this->{$relationName}()->get()->toArray()
         ];
         Event::dispatch(AuditCustom::class, [$this]);
+        $this->isCustomEvent = false;
         return empty($results) ? 0 : $results;
     }
 
@@ -690,6 +692,7 @@ trait Auditable
             $relationName => $this->{$relationName}()->get()->isEmpty() ? [] : $this->{$relationName}()->get()->toArray()
         ];
         Event::dispatch(AuditCustom::class, [$this]);
+        $this->isCustomEvent = false;
         return $changes;
     }
 

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -17,8 +17,6 @@ use OwenIt\Auditing\Exceptions\AuditingException;
 
 trait Auditable
 {
-
-
     /**
      * Auditable attributes excluded from the Audit.
      *


### PR DESCRIPTION
### What problem are you trying to solve?

Consider we have an eloquent **Post** model and a `BelongsToMany` relationship with **Tags**. In **Post** `booted` method, we handle the detaching of **Tags** like:

```php
protected static function booted()
{
    static::deleting(function (self $post) {
        $post->auditDetach('posts');
    });
}
```

When deleting a post, we are detaching the tags first. This creates an audit with the event "detach". Then, the Post is deleted and a "delete" audit event is stored. But the audit values are not correct; they are actually the `old_values` and `new_values` of the detach event.

### How

Adding `$post->isCustomEvent = false;` after the `$post->auditDetach()` fixes the issue in userland. So this PR sets the `$isCustomEvent` property to `false` after the auditAttach, auditDetach & auditSync methods.