### PR TITLE
Don't audit if there aren't any changes (except for retrieving models)

### DIFF
--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -78,6 +78,14 @@ class Auditor extends Manager implements Contracts\Auditor
             }
         }
 
+        //Don't store audits if there are no changes, expect for 'retrieved' events
+        if (
+            $model->toAudit()['new_values'] == $model->toAudit()['old_values'] &&
+            !in_array($model->getAuditEvent(), ['retrieved'])
+        ) {
+            return;
+        }
+
         $audit = $driver->audit($model);
         if (!$audit) {
             return;

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -23,7 +23,6 @@ class AuditingTest extends AuditingTestCase
 {
     use WithFaker;
 
-    
     /**
      * @test
      */


### PR DESCRIPTION
This PR prevents auditSync() to create a new record when there are no changes. 

Before, if a call was made to auditSync(), it would create a new audit record, regardless if there where any changes or not. 

This query shouldn't return any records:
``` sql
select *
from audits 
where event = 'sync'
and old_values = new_values
```