### PR TITLE
Add option to skip auditSync when sync has no changes

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -96,13 +96,18 @@ return [
     |
     | Some events may be empty on purpose. Use allowed_empty_values to exclude
     | those from the empty values check. For example when auditing
-    | model retrieved events which will never have new and old values
+    | model retrieved events which will never have new and old values.
+    |
+    | When using empty_values => true, you can still exclude certain events
+    | with empty values by specifying them in disallowed_empty_values.
     |
     */
 
     'empty_values'         => true,
     'allowed_empty_values' => [
         'retrieved'
+    ],
+    'disallowed_empty_values' => [
     ],
 
     /*

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -681,6 +681,8 @@ trait Auditable
             throw new AuditingException('Relationship ' . $relationName . ' was not found or does not support method sync');
         }
 
+        $this->auditEvent = 'sync';
+
         $this->auditCustomOld = [
             $relationName => $this->{$relationName}()->get()->isEmpty() ? [] : $this->{$relationName}()->get()->toArray()
         ];
@@ -690,13 +692,14 @@ trait Auditable
             return $changes;
         }
 
-        $this->auditEvent = 'sync';
-        $this->isCustomEvent = true;
         $this->auditCustomNew = [
             $relationName => $this->{$relationName}()->get()->isEmpty() ? [] : $this->{$relationName}()->get()->toArray()
         ];
+
+        $this->isCustomEvent = true;
         Event::dispatch(AuditCustom::class, [$this]);
         $this->isCustomEvent = false;
+
         return $changes;
     }
 

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -67,12 +67,15 @@ class Auditor extends Manager implements Contracts\Auditor
             return;
         }
 
-        // If we want to avoid storing Audits with empty old_values & new_values, return null here.
-        if (!Config::get('audit.empty_values')) {
+        // Check if we want to avoid storing empty values
+        $allowEmpty = Config::get('audit.empty_values');
+        $explicitAllowEmpty = in_array($model->getAuditEvent(), Config::get('audit.allowed_empty_values', []));
+        $explicitDisallowEmpty = in_array($model->getAuditEvent(), Config::get('audit.disallowed_empty_values', []));
+
+        if ($explicitDisallowEmpty || (!$allowEmpty && !$explicitAllowEmpty)) {
             if (
                 empty($model->toAudit()['new_values']) &&
-                empty($model->toAudit()['old_values']) &&
-                !in_array($model->getAuditEvent(), Config::get('audit.allowed_empty_values'))
+                empty($model->toAudit()['old_values'])
             ) {
                 return;
             }

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -631,8 +631,10 @@ class AuditingTest extends AuditingTestCase
      * @test
      * @return void
      */
-    public function itWillAuditSyncWhenSkipUnchangedPassed()
+    public function itWillAuditSyncWhenSkippingEmptyValues()
     {
+        $this->app['config']->set('audit.empty_values', false);
+
         $firstCategory = factory(Category::class)->create();
         $secondCategory = factory(Category::class)->create();
         $article = factory(Article::class)->create();
@@ -642,7 +644,7 @@ class AuditingTest extends AuditingTestCase
         $no_of_audits_before = Audit::where('auditable_type', Article::class)->count();
         $categoryBefore = $article->categories()->first()->getKey();
 
-        $article->auditSyncIfChanged('categories', [$secondCategory->getKey()]);
+        $article->auditSync('categories', [$secondCategory->getKey()]);
 
         $no_of_audits_after = Audit::where('auditable_type', Article::class)->count();
         $categoryAfter = $article->categories()->first()->getKey();
@@ -657,8 +659,10 @@ class AuditingTest extends AuditingTestCase
      * @test
      * @return void
      */
-    public function itWillNotAuditSyncWhenSkipUnchangedPassedButNoChanges()
+    public function itWillNotAuditSyncWhenSkippingEmptyValuesAndNoChangesMade()
     {
+        $this->app['config']->set('audit.empty_values', false);
+
         $firstCategory = factory(Category::class)->create();
         $article = factory(Article::class)->create();
 
@@ -667,7 +671,7 @@ class AuditingTest extends AuditingTestCase
         $no_of_audits_before = Audit::where('auditable_type', Article::class)->count();
         $categoryBefore = $article->categories()->first()->getKey();
 
-        $article->auditSyncIfChanged('categories', [$firstCategory->getKey()]);
+        $article->auditSync('categories', [$firstCategory->getKey()]);
 
         $no_of_audits_after = Audit::where('auditable_type', Article::class)->count();
         $categoryAfter = $article->categories()->first()->getKey();

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -23,7 +23,7 @@ class AuditingTest extends AuditingTestCase
 {
     use WithFaker;
 
-    
+
     /**
      * @test
      */
@@ -574,6 +574,108 @@ class AuditingTest extends AuditingTestCase
             $secondCategory->name,
             $article->audits->last()->getModified()['categories']['new'][1]['name']
         );
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function itWillAuditSync()
+    {
+        $firstCategory = factory(Category::class)->create();
+        $secondCategory = factory(Category::class)->create();
+        $article = factory(Article::class)->create();
+
+        $article->categories()->attach($firstCategory);
+
+        $no_of_audits_before = Audit::where('auditable_type', Article::class)->count();
+        $categoryBefore = $article->categories()->first()->getKey();
+
+        $article->auditSync('categories', [$secondCategory->getKey()]);
+
+        $no_of_audits_after = Audit::where('auditable_type', Article::class)->count();
+        $categoryAfter = $article->categories()->first()->getKey();
+
+        $this->assertSame($firstCategory->getKey(), $categoryBefore);
+        $this->assertSame($secondCategory->getKey(), $categoryAfter);
+        $this->assertNotSame($categoryBefore, $categoryAfter);
+        $this->assertGreaterThan($no_of_audits_before, $no_of_audits_after);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function itWillAuditSyncWithoutChanges()
+    {
+        $firstCategory = factory(Category::class)->create();
+        $article = factory(Article::class)->create();
+
+        $article->categories()->attach($firstCategory);
+
+        $no_of_audits_before = Audit::where('auditable_type', Article::class)->count();
+        $categoryBefore = $article->categories()->first()->getKey();
+
+        $article->auditSync('categories', [$firstCategory->getKey()]);
+
+        $no_of_audits_after = Audit::where('auditable_type', Article::class)->count();
+        $categoryAfter = $article->categories()->first()->getKey();
+
+        $this->assertSame($firstCategory->getKey(), $categoryBefore);
+        $this->assertSame($firstCategory->getKey(), $categoryAfter);
+        $this->assertSame($categoryBefore, $categoryAfter);
+        $this->assertGreaterThan($no_of_audits_before, $no_of_audits_after);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function itWillAuditSyncWhenSkipUnchangedPassed()
+    {
+        $firstCategory = factory(Category::class)->create();
+        $secondCategory = factory(Category::class)->create();
+        $article = factory(Article::class)->create();
+
+        $article->categories()->attach($firstCategory);
+
+        $no_of_audits_before = Audit::where('auditable_type', Article::class)->count();
+        $categoryBefore = $article->categories()->first()->getKey();
+
+        $article->auditSyncIfChanged('categories', [$secondCategory->getKey()]);
+
+        $no_of_audits_after = Audit::where('auditable_type', Article::class)->count();
+        $categoryAfter = $article->categories()->first()->getKey();
+
+        $this->assertSame($firstCategory->getKey(), $categoryBefore);
+        $this->assertSame($secondCategory->getKey(), $categoryAfter);
+        $this->assertNotSame($categoryBefore, $categoryAfter);
+        $this->assertGreaterThan($no_of_audits_before, $no_of_audits_after);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function itWillNotAuditSyncWhenSkipUnchangedPassedButNoChanges()
+    {
+        $firstCategory = factory(Category::class)->create();
+        $article = factory(Article::class)->create();
+
+        $article->categories()->attach($firstCategory);
+
+        $no_of_audits_before = Audit::where('auditable_type', Article::class)->count();
+        $categoryBefore = $article->categories()->first()->getKey();
+
+        $article->auditSyncIfChanged('categories', [$firstCategory->getKey()]);
+
+        $no_of_audits_after = Audit::where('auditable_type', Article::class)->count();
+        $categoryAfter = $article->categories()->first()->getKey();
+
+        $this->assertSame($firstCategory->getKey(), $categoryBefore);
+        $this->assertSame($firstCategory->getKey(), $categoryAfter);
+        $this->assertSame($categoryBefore, $categoryAfter);
+        $this->assertSame($no_of_audits_before, $no_of_audits_after);
     }
 
     /**


### PR DESCRIPTION
We found that often we are storing models to make minor changes but some relationships are not changed. If we do a `auditSync` call, we will get an audit even if the relationship was not affected. 

This PR adds a method `auditSyncIfChanged` which will abort the audit when it finds the relationship sync() call had 0 attached, updated or detached items.