### PR TITLE
Handle default timezones properly (fixes #709)

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -243,10 +243,6 @@ trait Audit
 
             $value = $this->getDataValue($key);
             $modified[$attribute][$state] = $value;
-
-            if ($value instanceof DateTimeInterface) {
-                $modified[$attribute][$state] = !is_null($this->auditable) ? $this->auditable->serializeDate($value) : $this->serializeDate($value);
-            }
         }
 
         return $json ? json_encode($modified, $options, $depth) : $modified;


### PR DESCRIPTION
Return values implementing `DateTimeInterface` directly in `getModified` instead of serializing before passing to the `Auditable`'s `setAttribute` function.

`setAttribute` handles values that implement `DateTimeInterface` properly, but does not handle serialized dates properly. Since Laravel 7 dates are serialized to a format like:
```"2022-04-06T12:53:18Z"```

`setAttribute` expects dates to be in the same format the database would use, which is typically something like:
```"2022-04-06 12:53:18"```

Because the expected format does not include a timezone, the timezone is ignored. When a default timezone is set, that means that the datetime value gets converted to UTC by the `serializeDate` function, then gets unserialized and treated as the default timezone by `setAttribute`. Ultimately, `"2022-04-06 12:00:00 America/New_York"` becomes `"2022-04-06T17:00:00Z"` becomes `"2022-04-06 17:00:0 America/New_York"`.