### PR TITLE
User morph prefix from config on migration

### DIFF
--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 
 class CreateAuditsTable extends Migration
@@ -14,9 +15,11 @@ class CreateAuditsTable extends Migration
     public function up()
     {
         Schema::create('audits', function (Blueprint $table) {
+            $morphPrefix = Config::get('audit.user.morph_prefix', 'user');
+
             $table->bigIncrements('id');
-            $table->string('user_type')->nullable();
-            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string($morphPrefix . '_type')->nullable();
+            $table->unsignedBigInteger($morphPrefix . '_id')->nullable();
             $table->string('event');
             $table->morphs('auditable');
             $table->text('old_values')->nullable();
@@ -27,7 +30,7 @@ class CreateAuditsTable extends Migration
             $table->string('tags')->nullable();
             $table->timestamps();
 
-            $table->index(['user_id', 'user_type']);
+            $table->index([$morphPrefix . '_id', $morphPrefix . '_type']);
         });
     }
 


### PR DESCRIPTION
On migration use setted morph prefix from config, same as other places
https://github.com/owen-it/laravel-auditing/blob/2317a5ed72f0c4256b1c274d3e6ef53db5d0598c/src/Auditable.php#L320
https://github.com/owen-it/laravel-auditing/blob/2317a5ed72f0c4256b1c274d3e6ef53db5d0598c/src/Auditable.php#L332-L333