### PR TITLE
Fix attributes with enums being excluded from audit

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -115,7 +115,12 @@ trait Auditable
 
         foreach ($attributes as $attribute => $value) {
             // Apart from null, non scalar values will be excluded
-            if (is_array($value) || (is_object($value) && !method_exists($value, '__toString'))) {
+            if (
+                is_array($value) ||
+                (is_object($value) &&
+                    !method_exists($value, '__toString') &&
+                    !($value instanceof \UnitEnum))
+            ) {
                 $this->excludedAttributes[] = $attribute;
             }
         }


### PR DESCRIPTION
This will fix attributes with enum values from being automatically excluded.
For details look at [this](https://github.com/owen-it/laravel-auditing/issues/722) issue.
