### PR TITLE
Use configured db connection in default migration

### DIFF
--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -13,7 +13,7 @@ class CreateAuditsTable extends Migration
      */
     public function up()
     {
-        Schema::create('audits', function (Blueprint $table) {
+        Schema::connection(config('audit.drivers.database.connection', config('database.default')))->create('audits', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('user_type')->nullable();
             $table->unsignedBigInteger('user_id')->nullable();
@@ -38,6 +38,6 @@ class CreateAuditsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('audits');
+        Schema::connection(config('audit.drivers.database.connection', config('database.default')))->drop('audits');
     }
 }


### PR DESCRIPTION
If the user specifies a different db connection for the audits table in their config file than the one used by the rest of the app, the default migration would not take this into account. Personally I use a different database for my audits table so I needed to modify the migration like I've done in this PR.