### PR TITLE
Restore Lumen support

### DIFF
--- a/src/AuditingEventServiceProvider.php
+++ b/src/AuditingEventServiceProvider.php
@@ -2,7 +2,11 @@
 
 namespace OwenIt\Auditing;
 
-use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+if (app() instanceof \Illuminate\Foundation\Application) {
+    class_alias(\Illuminate\Foundation\Support\Providers\EventServiceProvider::class, '\OwenIt\Auditing\ServiceProvider');
+} else {
+    class_alias(\Laravel\Lumen\Providers\EventServiceProvider::class, '\OwenIt\Auditing\ServiceProvider');
+}
 use OwenIt\Auditing\Events\AuditCustom;
 use OwenIt\Auditing\Listeners\RecordCustomAudit;
 


### PR DESCRIPTION
Closes #728

Another option could be creating a especific event service provider only for lumen, like `AuditingLumenEventServiceProvider::class`
```php
// AuditingServiceProvider.php
public function register()
{
  /////
  if ($this->app instanceof \Illuminate\Foundation\Application) {
      $this->app->register(AuditingEventServiceProvider::class);
  } else {
      $this->app->register(AuditingLumenEventServiceProvider::class);
  }
  /////
```