### PR TITLE
Fix old resolvers config deprecation

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -375,13 +375,14 @@ trait Auditable
     protected function runResolvers(): array
     {
         $resolved = [];
-        if (Config::has('audit.resolver')) {
+        $resolvers = Config::get('audit.resolvers', []);
+        if (empty($resolvers) && Config::has('audit.resolver')) {
             trigger_error('The config file audit.php is not updated to the new version 13.0. Please see https://www.laravel-auditing.com/docs/13.0/upgrading',
                 E_USER_DEPRECATED);
-            return [];
+            $resolvers = Config::get('audit.resolver', []);
         }
 
-        foreach (Config::get('audit.resolvers', []) as $name => $implementation) {
+        foreach ($resolvers as $name => $implementation) {
             if (empty($implementation)) {
                 continue;
             }


### PR DESCRIPTION
Deprecation not means break old functionality

https://en.wikipedia.org/wiki/Deprecation
>Typically, deprecated materials are not completely removed to ensure legacy compatibility or back up practice ...
>It can also imply that a feature, design, or practice will be removed or discontinued entirely in the future.

Same logic from `UserResolver`: (it get the value from old deprected config)
https://github.com/owen-it/laravel-auditing/blob/240b29a1e6c40c02ed1fb9b4c01ef94d6d4ff7c0/src/Auditable.php#L360-L366


