### PR TITLE
(fix): UserResolver authenticatable import

### DIFF
--- a/src/Contracts/UserResolver.php
+++ b/src/Contracts/UserResolver.php
@@ -2,14 +2,13 @@
 
 namespace OwenIt\Auditing\Contracts;
 
-use Illuminate\Contracts\Auth\Authenticatable;
 
 interface UserResolver
 {
     /**
      * Resolve the User.
      *
-     * @return Authenticatable|null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */
     public static function resolve();
 }

--- a/src/Contracts/UserResolver.php
+++ b/src/Contracts/UserResolver.php
@@ -2,7 +2,7 @@
 
 namespace OwenIt\Auditing\Contracts;
 
-use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 interface UserResolver
 {

--- a/src/Contracts/UserResolver.php
+++ b/src/Contracts/UserResolver.php
@@ -2,7 +2,6 @@
 
 namespace OwenIt\Auditing\Contracts;
 
-
 interface UserResolver
 {
     /**


### PR DESCRIPTION
The UserResolver demanded a trait as a return type, which should have been the Authenticatable Contract. This is most likely an auto completion error.


Found while using PhpStan level 9 locally.