### PR TITLE
Added $auditTags for flexible adding of tags

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -25,6 +25,13 @@ trait Auditable
     protected $excludedAttributes = [];
 
     /**
+     * Tags to be included when saving the audit
+     *
+     * @var array
+     */
+    protected $auditTags = [];
+    
+    /**
      * Audit event name.
      *
      * @var string
@@ -570,7 +577,7 @@ trait Auditable
      */
     public function generateTags(): array
     {
-        return [];
+        return $this->auditTags;
     }
 
     /**


### PR DESCRIPTION
Adding this variable and returning it from generateTags makes is much more flexible to set tags from the model class.