### PR TITLE
Fix disable auditing before model initialization

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -63,7 +63,7 @@ trait Auditable
      */
     public static function bootAuditable()
     {
-        if (!self::$auditingDisabled && static::isAuditingEnabled()) {
+        if (static::isAuditingEnabled()) {
             static::observe(new AuditableObserver());
         }
     }

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -409,6 +409,31 @@ class AuditingTest extends AuditingTestCase
 
     /**
      * @test
+     */
+    public function itDisablesAndEnablesAuditingBackAgainViaFacade()
+    {
+        // Auditing is enabled by default
+        $this->assertFalse(Article::$auditingDisabled);
+
+        Article::disableAuditing();
+
+        factory(Article::class)->create();
+
+        $this->assertSame(1, Article::count());
+        $this->assertSame(0, Audit::count());
+
+        // Enable Auditing
+        Article::enableAuditing();
+        $this->assertFalse(Article::$auditingDisabled);
+
+        factory(Article::class)->create();
+
+        $this->assertSame(2, Article::count());
+        $this->assertSame(1, Audit::count());
+    }
+
+    /**
+     * @test
      * @return void
      */
     public function itHandlesJsonColumnsCorrectly()

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -75,15 +75,16 @@ class AuditableTest extends AuditingTestCase
      * @group Auditable::bootAuditable
      * @test
      */
-    public function itWillNotBootTraitWhenStaticFlagIsSet()
+    public function itWillBootTraitWhenStaticFlagIsSet()
     {
         App::spy();
 
         Article::$auditingDisabled = true;
 
-        new Article();
+        $article = new Article();
 
-        App::shouldNotHaveReceived('runningInConsole');
+        $this->assertFalse($article->readyForAuditing());
+        App::shouldReceive('runningInConsole');
 
         Article::$auditingDisabled = false;
     }


### PR DESCRIPTION
The `Auditable::bootAuditable()` trait loader on the model works only once, at the very first initialization of the class. Thus, at the moment, if auditing is disabled on the model during initialization, an observer will not be booted on the model, and a further call to `Model::enableAudit()` will not change anything - there is no observer, no events are registered.

The `itDisablesAndEnablesAuditingBackAgain` test skipped this behavior because the model was first initialized before auditing was disabled.

I suggest init observer on the model, regardless of the `$auditingDisabled` flag. I made the appropriate changes, and the `itDisablesAndEnablesAuditingBackAgainViaFacade` test, where auditing is disabled before initialization.