### PR TITLE
Feat/add async support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "owen-it/laravel-auditing",
+    "name": "snappshop/laravel-auditing-with-async",
     "description": "Audit changes of your Eloquent models in Laravel/Lumen",
     "keywords": [
         "accountability",
@@ -17,7 +17,6 @@
         "revision",
         "tracking"
     ],
-    "homepage": "http://laravel-auditing.com",
     "type": "package",
     "license": "MIT",
     "support": {
@@ -36,6 +35,10 @@
         {
             "name": "Morten D. Hansen",
             "email": "morten@visia.dk"
+        },
+        {
+            "name": "Hamed Hosseini",
+            "email": "hamedmax73@gmail.com"
         }
     ],
     "require": {
@@ -61,9 +64,6 @@
             "OwenIt\\Auditing\\Tests\\": "tests/"
         }
     },
-    "suggest": {
-        "laravelista/lumen-vendor-publish": "Needed to publish the package configuration in Lumen"
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "v13-dev"
@@ -73,7 +73,5 @@
                 "OwenIt\\Auditing\\AuditingServiceProvider"
             ]
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/config/audit.php
+++ b/config/audit.php
@@ -24,13 +24,13 @@ return [
     |
     */
 
-    'user'      => [
+    'user' => [
         'morph_prefix' => 'user',
-        'guards'       => [
+        'guards' => [
             'web',
             'api'
         ],
-        'resolver'     => OwenIt\Auditing\Resolvers\UserResolver::class
+        'resolver' => OwenIt\Auditing\Resolvers\UserResolver::class
     ],
 
     /*
@@ -44,7 +44,7 @@ return [
     'resolvers' => [
         'ip_address' => OwenIt\Auditing\Resolvers\IpAddressResolver::class,
         'user_agent' => OwenIt\Auditing\Resolvers\UserAgentResolver::class,
-        'url'        => OwenIt\Auditing\Resolvers\UrlResolver::class,
+        'url' => OwenIt\Auditing\Resolvers\UrlResolver::class,
     ],
 
     /*
@@ -101,7 +101,7 @@ return [
     |
     */
 
-    'empty_values'         => true,
+    'empty_values' => true,
     'allowed_empty_values' => [
         'retrieved'
     ],
@@ -151,7 +151,7 @@ return [
 
     'drivers' => [
         'database' => [
-            'table'      => 'audits',
+            'table' => 'audits',
             'connection' => null,
         ],
     ],
@@ -166,4 +166,15 @@ return [
     */
 
     'console' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Audit Job Queue
+    |--------------------------------------------------------------------------
+    |
+    | Name of queue that job dispatch on that
+    |
+    */
+    'should_queue' => true,
+    'job_queue_name' => 'audit',
 ];

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -88,7 +88,7 @@ trait Auditable
     {
         $this->excludedAttributes = $this->getAuditExclude();
 
-        // When in strict mode, hidden and non visible attributes are excluded
+        // When in strict mode, hidden and non-visible attributes are excluded
         if ($this->getAuditStrict()) {
             // Hidden attributes
             $this->excludedAttributes = array_merge($this->excludedAttributes, $this->hidden);

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -545,6 +545,15 @@ trait Auditable
     }
 
     /**
+     * check we should queue the audit or not
+     * @return bool
+     */
+    public function getShouldQueue(): bool
+    {
+        return $this->shouldQueue ?? Config::get('audit.should_queue', true);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getAuditTimestamps(): bool

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -25,6 +25,12 @@ trait Auditable
     protected $excludedAttributes = [];
 
     /**
+     * List of resolvers.
+     * @var array
+     */
+    public $appendedResolver = [];
+
+    /**
      * Audit event name.
      *
      * @var string
@@ -312,6 +318,11 @@ trait Auditable
 
         list($old, $new) = $this->$attributeGetter();
 
+        //if we dose not has any resolvers, we must run resolvers
+        if (empty($this->appendedResolver)) {
+            $this->appendedResolver = $this->runResolvers();
+        }
+
         if ($this->getAttributeModifiers() && !$this->isCustomEvent) {
             foreach ($old as $attribute => $value) {
                 $old[$attribute] = $this->modifyAttributeValue($attribute, $value);
@@ -329,15 +340,15 @@ trait Auditable
         $user = $this->resolveUser();
 
         return $this->transformAudit(array_merge([
-            'old_values'           => $old,
-            'new_values'           => $new,
-            'event'                => $this->auditEvent,
-            'auditable_id'         => $this->getKey(),
-            'auditable_type'       => $this->getMorphClass(),
-            $morphPrefix . '_id'   => $user ? $user->getAuthIdentifier() : null,
+            'old_values' => $old,
+            'new_values' => $new,
+            'event' => $this->auditEvent,
+            'auditable_id' => $this->getKey(),
+            'auditable_type' => $this->getMorphClass(),
+            $morphPrefix . '_id' => $user ? $user->getAuthIdentifier() : null,
             $morphPrefix . '_type' => $user ? $user->getMorphClass() : null,
-            'tags'                 => empty($tags) ? null : $tags,
-        ], $this->runResolvers()));
+            'tags' => empty($tags) ? null : $tags,
+        ], $this->appendedResolver));
     }
 
     /**
@@ -374,7 +385,7 @@ trait Auditable
         throw new AuditingException('Invalid UserResolver implementation');
     }
 
-    protected function runResolvers(): array
+    public function runResolvers(): array
     {
         $resolved = [];
         $resolvers = Config::get('audit.resolvers', []);
@@ -484,11 +495,11 @@ trait Auditable
     public function getAuditEvents(): array
     {
         return $this->auditEvents ?? Config::get('audit.events', [
-                'created',
-                'updated',
-                'deleted',
-                'restored',
-            ]);
+            'created',
+            'updated',
+            'deleted',
+            'restored',
+        ]);
     }
 
     /**

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -80,11 +80,12 @@ class Auditor extends Manager implements Contracts\Auditor
                 return;
             }
         }
+
+        //check for queue
         $jobQueueName = Config::get('audit.job_queue_name');
+        $shouldQueue = $model->getShouldQueue();
         $allowQueue = Config::get('audit.should_queue');
-
-
-        if ($allowQueue) {
+        if ($allowQueue && $shouldQueue) {
             //attach resolvers to use in jobs
             $resolvers = $model->runResolvers();
             AuditModelChanges::dispatch($driver, $model, $resolvers, $model->getAuditEvent())->onQueue($jobQueueName);

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -83,8 +83,11 @@ class Auditor extends Manager implements Contracts\Auditor
         $jobQueueName = Config::get('audit.job_queue_name');
         $allowQueue = Config::get('audit.should_queue');
 
+
         if ($allowQueue) {
-            AuditModelChanges::dispatch($driver, $model, $model->getAuditEvent())->onQueue($jobQueueName);
+            //attach resolvers to use in jobs
+            $resolvers = $model->runResolvers();
+            AuditModelChanges::dispatch($driver, $model, $resolvers, $model->getAuditEvent())->onQueue($jobQueueName);
         } else {
             $audit = $driver->audit($model);
             if (!$audit) {

--- a/src/Jobs/AuditModelChanges.php
+++ b/src/Jobs/AuditModelChanges.php
@@ -28,17 +28,19 @@ class AuditModelChanges implements ShouldQueue
     public $model;
     public $auditDriver;
     public $event;
+    public $resolvers;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct(AuditDriver $auditDriver, Auditable $model, $event)
+    public function __construct(AuditDriver $auditDriver, Auditable $model, $resolvers, $event)
     {
         $this->auditDriver = $auditDriver;
         $this->model = $model;
         $this->event = $event;
+        $this->resolvers = $resolvers;
     }
 
     /**
@@ -49,6 +51,7 @@ class AuditModelChanges implements ShouldQueue
     public function handle()
     {
         $this->model->setAuditEvent($this->event);
+        $this->model->appendedResolver = $this->resolvers;
         $audit = $this->auditDriver->audit($this->model);
         if (!$audit) {
             $this->fail();

--- a/src/Jobs/AuditModelChanges.php
+++ b/src/Jobs/AuditModelChanges.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace OwenIt\Auditing\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
+use OwenIt\Auditing\Contracts\Auditable;
+use OwenIt\Auditing\Contracts\AuditDriver;
+use OwenIt\Auditing\Events\Audited;
+use Throwable;
+
+class AuditModelChanges implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 120;
+
+    public $model;
+    public $auditDriver;
+    public $event;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(AuditDriver $auditDriver, Auditable $model, $event)
+    {
+        $this->auditDriver = $auditDriver;
+        $this->model = $model;
+        $this->event = $event;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->model->setAuditEvent($this->event);
+        $audit = $this->auditDriver->audit($this->model);
+        if (!$audit) {
+            $this->fail();
+        }
+        App::make('events')->dispatch(
+            new Audited($this->model, $this->auditDriver, $audit)
+        );
+    }
+
+    /**
+     * Handle a job failure.
+     *
+     * @param \Throwable $exception
+     * @return void
+     */
+    public function failed(Throwable $exception)
+    {
+        Log::info('error in auditing data with job' . $exception->getMessage() . " error code: " . $exception->getCode());
+    }
+}

--- a/src/Resolvers/UrlResolver.php
+++ b/src/Resolvers/UrlResolver.php
@@ -13,9 +13,9 @@ class UrlResolver implements \OwenIt\Auditing\Contracts\Resolver
      */
     public static function resolve(Auditable $auditable): string
     {
-//        if (App::runningInConsole()) {
-//            return 'console';
-//        }
+        if (App::runningInConsole()) {
+            return 'console';
+        }
 
         return Request::fullUrl();
     }

--- a/src/Resolvers/UrlResolver.php
+++ b/src/Resolvers/UrlResolver.php
@@ -13,9 +13,9 @@ class UrlResolver implements \OwenIt\Auditing\Contracts\Resolver
      */
     public static function resolve(Auditable $auditable): string
     {
-        if (App::runningInConsole()) {
-            return 'console';
-        }
+//        if (App::runningInConsole()) {
+//            return 'console';
+//        }
 
         return Request::fullUrl();
     }


### PR DESCRIPTION
sample for use queue:
You may set a default exclude set in the config.

1- first config this setups:

```
'should_queue' => true,

'job_queue_name' => 'audit',
```

2- you can disable this setup in your model

This is done on a per `Auditable` model basis, by assigning a `bool` value to the `$shouldQueue` attribute.

```
    protected bool $shouldQueue = false;
```

3- after that you must run your queue


----
in case of manually publish entity changes use this sample:
```
        User::disableAuditing();
            //user mmodel update or create or ...
        User::enableAuditing();
            //save it manually
        if ($audit = Auditor::execute($createdUser)) {
            Auditor::prune($createdUser);
        }

```

-----

read the real document:
https://laravel-auditing.com/docs/13.0/introduction