### PR TITLE
Custom table name from config

### DIFF
--- a/database/migrations/audits.stub
+++ b/database/migrations/audits.stub
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 
 class CreateAuditsTable extends Migration
@@ -14,10 +13,13 @@ class CreateAuditsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(config('audit.drivers.database.connection', config('database.default')))->create('audits', function (Blueprint $table) {
-        
-            $morphPrefix = Config::get('audit.user.morph_prefix', 'user');
-            
+        $connection = config('audit.drivers.database.connection', config('database.default'));
+        $table = config('audit.drivers.database.table', 'audits');
+
+        Schema::connection($connection)->create($table, function (Blueprint $table) {
+
+            $morphPrefix = config('audit.user.morph_prefix', 'user');
+
             $table->bigIncrements('id');
             $table->string($morphPrefix . '_type')->nullable();
             $table->unsignedBigInteger($morphPrefix . '_id')->nullable();
@@ -42,6 +44,9 @@ class CreateAuditsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(config('audit.drivers.database.connection', config('database.default')))->drop('audits');
+        $connection = config('audit.drivers.database.connection', config('database.default'));
+        $table = config('audit.drivers.database.table', 'audits');
+
+        Schema::connection($connection)->drop($table);
     }
 }

--- a/tests/AuditingTestCase.php
+++ b/tests/AuditingTestCase.php
@@ -25,6 +25,7 @@ class AuditingTestCase extends TestCase
         ]);
 
         // Audit
+        $app['config']->set('audit.drivers.database.table', 'audit_testing');
         $app['config']->set('audit.drivers.database.connection', 'testing');
         $app['config']->set('audit.user.morph_prefix', 'user');
         $app['config']->set('audit.user.resolver', UserResolver::class);

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -699,7 +699,7 @@ class AuditingTest extends AuditingTestCase
         ];
         Event::dispatch(AuditCustom::class, [$article]);
 
-        $this->assertDatabaseHas('audits', [
+        $this->assertDatabaseHas(config('audit.drivers.database.table', 'audits'), [
             'auditable_id'   => $article->id,
             'auditable_type' => Article::class,
             'event'          => 'whateverYouWant',

--- a/tests/database/migrations/0000_00_00_000001_create_audits_test_table.php
+++ b/tests/database/migrations/0000_00_00_000001_create_audits_test_table.php
@@ -1,11 +1,12 @@
 <?php
+include_once __DIR__.'/../../../database/migrations/audits.stub';
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateAuditsTestTable extends Migration
+class CreateAuditsTestTable extends CreateAuditsTable
 {
+
     /**
      * Run the migrations.
      *
@@ -13,32 +14,10 @@ class CreateAuditsTestTable extends Migration
      */
     public function up()
     {
-        Schema::create('audits', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('user_type')->nullable();
-            $table->unsignedBigInteger('user_id')->nullable();
-            $table->string('event');
-            $table->morphs('auditable');
-            $table->text('old_values')->nullable();
-            $table->text('new_values')->nullable();
-            $table->text('url')->nullable();
-            $table->ipAddress('ip_address')->nullable();
-            $table->string('user_agent')->nullable();
-            $table->string('tags')->nullable();
+        parent::up();
+
+        Schema::table(config('audit.drivers.database.table', 'audits'), function(Blueprint $table) {
             $table->unsignedInteger('tenant_id')->nullable();
-            $table->timestamps();
-
-            $table->index(['user_id', 'user_type']);
         });
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('audits');
     }
 }


### PR DESCRIPTION
On config we have `audit.drivers.database.table` but on migration it is never called, this PR fix migration

- Clean trailing spaces on migration
- Use table name from config `$table = config('audit.drivers.database.table', 'audits');`
- Use a custom table name on tests, this test that functionality
- Test original [audits migration](https://github.com/owen-it/laravel-auditing/blob/master/database/migrations/audits.stub) instead of [duplicate it](https://github.com/owen-it/laravel-auditing/blob/v13.1.0/tests/database/migrations/0000_00_00_000001_create_audits_test_table.php)

https://github.com/owen-it/laravel-auditing/blob/75b33ec9b4345e4539d94d6c28233b34c5d2730f/config/audit.php#L152-L157

**THIS PR DON'T BREAK PREVIOUS MIGRATIONS**