### PR TITLE
Fix custom morph prefix on user morphTo, with tests

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -44,7 +44,9 @@ trait Audit
      */
     public function user()
     {
-        return $this->morphTo();
+        $morphPrefix = Config::get('audit.user.morph_prefix', 'user');
+
+        return $this->morphTo(__FUNCTION__, $morphPrefix . '_type', $morphPrefix . '_id');
     }
 
     /**

--- a/tests/AuditingTestCase.php
+++ b/tests/AuditingTestCase.php
@@ -27,7 +27,7 @@ class AuditingTestCase extends TestCase
         // Audit
         $app['config']->set('audit.drivers.database.table', 'audit_testing');
         $app['config']->set('audit.drivers.database.connection', 'testing');
-        $app['config']->set('audit.user.morph_prefix', 'user');
+        $app['config']->set('audit.user.morph_prefix', 'prefix');
         $app['config']->set('audit.user.resolver', UserResolver::class);
         $app['config']->set('audit.user.guards', [
             'web',

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -403,6 +403,7 @@ class AuditableTest extends AuditingTestCase
 
         $this->assertCount(11, $auditData = $model->toAudit());
 
+        $morphPrefix = config('audit.user.morph_prefix', 'user');
         self::Assert()::assertArraySubset([
             'old_values'     => [],
             'new_values'     => [
@@ -411,15 +412,15 @@ class AuditableTest extends AuditingTestCase
                 'reviewed'     => 1,
                 'published_at' => $now->toDateTimeString(),
             ],
-            'event'          => 'created',
-            'auditable_id'   => null,
-            'auditable_type' => Article::class,
-            'user_id'        => null,
-            'user_type'      => null,
-            'url'            => 'console',
-            'ip_address'     => '127.0.0.1',
-            'user_agent'     => 'Symfony',
-            'tags'           => null,
+            'event'                 => 'created',
+            'auditable_id'          => null,
+            'auditable_type'        => Article::class,
+            $morphPrefix . '_id'    => null,
+            $morphPrefix . '_type'  => null,
+            'url'                   => 'console',
+            'ip_address'            => '127.0.0.1',
+            'user_agent'            => 'Symfony',
+            'tags'                  => null,
         ], $auditData, true);
     }
 
@@ -462,6 +463,7 @@ class AuditableTest extends AuditingTestCase
 
         $this->assertCount(11, $auditData = $model->toAudit());
 
+        $morphPrefix = config('audit.user.morph_prefix', 'user');
         self::Assert()::assertArraySubset([
             'old_values'     => [],
             'new_values'     => [
@@ -470,15 +472,15 @@ class AuditableTest extends AuditingTestCase
                 'reviewed'     => 1,
                 'published_at' => $now->toDateTimeString(),
             ],
-            'event'          => 'created',
-            'auditable_id'   => null,
-            'auditable_type' => Article::class,
-            'user_id'        => $id,
-            'user_type'      => $type,
-            'url'            => 'console',
-            'ip_address'     => '127.0.0.1',
-            'user_agent'     => 'Symfony',
-            'tags'           => null,
+            'event'                 => 'created',
+            'auditable_id'          => null,
+            'auditable_type'        => Article::class,
+            $morphPrefix . '_id'    => $id,
+            $morphPrefix . '_type'  => $type,
+            'url'                   => 'console',
+            'ip_address'            => '127.0.0.1',
+            'user_agent'            => 'Symfony',
+            'tags'                  => null,
         ], $auditData, true);
     }
 
@@ -544,21 +546,22 @@ class AuditableTest extends AuditingTestCase
 
         $this->assertCount(11, $auditData = $model->toAudit());
 
+        $morphPrefix = config('audit.user.morph_prefix', 'user');
         self::Assert()::assertArraySubset([
             'old_values'     => [],
             'new_values'     => [
                 'title'   => 'How To Audit Eloquent Models',
                 'content' => 'First step: install the laravel-auditing package.',
             ],
-            'event'          => 'created',
-            'auditable_id'   => null,
-            'auditable_type' => Article::class,
-            'user_id'        => null,
-            'user_type'      => null,
-            'url'            => 'console',
-            'ip_address'     => '127.0.0.1',
-            'user_agent'     => 'Symfony',
-            'tags'           => null,
+            'event'                 => 'created',
+            'auditable_id'          => null,
+            'auditable_type'        => Article::class,
+            $morphPrefix . '_id'    => null,
+            $morphPrefix . '_type'  => null,
+            'url'                   => 'console',
+            'ip_address'            => '127.0.0.1',
+            'user_agent'            => 'Symfony',
+            'tags'                  => null,
         ], $auditData, true);
     }
 

--- a/tests/database/factories/AuditFactory.php
+++ b/tests/database/factories/AuditFactory.php
@@ -13,11 +13,13 @@ use OwenIt\Auditing\Tests\Models\User;
 */
 
 $factory->define(Audit::class, function (Faker $faker) {
+    $morphPrefix = Config::get('audit.user.morph_prefix', 'user');
+
     return [
-        'user_id' => function () {
+        $morphPrefix . '_id' => function () {
             return factory(User::class)->create()->id;
         },
-        'user_type'    => User::class,
+        $morphPrefix . '_type'    => User::class,
         'event'        => 'updated',
         'auditable_id' => function () {
             return factory(Article::class)->create()->id;


### PR DESCRIPTION
`audit.user.morph_prefix` was not taken into account in the `morphTo` of `user()` relationship
```diff
public function user()
{
+    $morphPrefix = Config::get('audit.user.morph_prefix', 'user');

-    return $this->morphTo();
+    return $this->morphTo(__FUNCTION__, $morphPrefix . '_type', $morphPrefix . '_id');
}
```
**SOURCE:** [eloquent-relationships#morph-one-to-one-key-conventions](https://laravel.com/docs/10.x/eloquent-relationships#morph-one-to-one-key-conventions)
