### PR TITLE
Add DumpResolver for empty values when is needed

### DIFF
--- a/src/Resolvers/DumpResolver.php
+++ b/src/Resolvers/DumpResolver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OwenIt\Auditing\Resolvers;
+
+use OwenIt\Auditing\Contracts\Auditable;
+use OwenIt\Auditing\Contracts\Resolver;
+
+class DumpResolver implements Resolver
+{
+    public static function resolve(Auditable $auditable): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
https://github.com/owen-it/laravel-auditing/blob/75b33ec9b4345e4539d94d6c28233b34c5d2730f/config/audit.php#L44-L48
If we don't want any data
```php
'resolvers' => [ 
     'ip_address' => OwenIt\Auditing\Resolvers\DumpResolver::class, 
     'user_agent' => OwenIt\Auditing\Resolvers\DumpResolver::class, 
     'url'        => OwenIt\Auditing\Resolvers\DumpResolver::class, 
 ], 
```