### PR TITLE
fixing phpstan namespace issues

### DIFF
--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -9,7 +9,7 @@ interface Auditable
     /**
      * Auditable Model audits.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<OwenIt\Auditing\Models\Audit>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\OwenIt\Auditing\Models\Audit>
      */
     public function audits(): MorphMany;
 

--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -3,13 +3,14 @@
 namespace OwenIt\Auditing\Contracts;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use OwenIt\Auditing\Contracts\Audit as AuditContract;
 
 interface Auditable
 {
     /**
      * Auditable Model audits.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\OwenIt\Auditing\Models\Audit>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<AuditContract>
      */
     public function audits(): MorphMany;
 


### PR DESCRIPTION
``` 
Class OwenIt\Auditing\Contracts\OwenIt\Auditing\Models\Audit was not found while trying to analyse it - discovering symbols is probably not configured properly.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                  
```