### PR TITLE
Fix namespace for phpstan

### DIFF
--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -9,7 +9,7 @@ interface Auditable
     /**
      * Auditable Model audits.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<OwenIt\Auditing\Contracts\Audit>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\OwenIt\Auditing\Contracts\Audit>
      */
     public function audits(): MorphMany;
 


### PR DESCRIPTION
This was fixed on https://github.com/owen-it/laravel-auditing/pull/798/commits/6ebf17b875600340270351fa7d29138f4ea3fdd2
But it was break again on https://github.com/owen-it/laravel-auditing/pull/798/commits/b7f358a4bc6a09a6bfe3e839185896ad1bded895, https://github.com/owen-it/laravel-auditing/commit/37453d12f95cbca1a95a31e0b681b9474609453c
Was introduced on https://github.com/owen-it/laravel-auditing/pull/734
Closes #808
