### PR TITLE
Update phpstan-baseline.neon

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ CONTRIBUTING.md  export-ignore
 phpunit.xml      export-ignore
 README.md        export-ignore
 phpstan*         export-ignore
+.php-cs-fixer.dist.php export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 composer.lock
 .vscode
 .phpunit.result.cache
-.php-cs-fixer.php
+.php-cs-fixer.cache

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,6 @@
 parameters:
 	ignoreErrors:
+		-
+			message: "#^Called 'slice' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: src/Drivers/Database.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,7 +9,7 @@ parameters:
     paths:
         - src
         - config
-        - database
+        - database/migrations/audits.stub
         - stubs
     tmpDir: build/phpstan
     checkOctaneCompatibility: true

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -166,7 +166,9 @@ trait Audit
         }
 
         if (preg_match('/^(\d{4})-(\d{1,2})-(\d{1,2})$/', $value)) {
-            return Date::instance(Carbon::createFromFormat('Y-m-d', $value, Date::now('UTC')->getTimezone())->startOfDay());
+            $date = Carbon::createFromFormat('Y-m-d', $value, Date::now('UTC')->getTimezone());
+
+            return $date ? Date::instance($date->startOfDay()) : $value;
         }
 
         if (preg_match('/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/', $value)) {

--- a/src/AuditingServiceProvider.php
+++ b/src/AuditingServiceProvider.php
@@ -78,7 +78,7 @@ class AuditingServiceProvider extends ServiceProvider implements DeferrableProvi
     /**
      * Returns existing migration file if found, else uses the current timestamp.
      */
-    protected function getMigrationFileName($migrationFileName): string
+    protected function getMigrationFileName(string $migrationFileName): string
     {
         $timestamp = date('Y_m_d_His');
 


### PR DESCRIPTION
Lats fixes for #810
an `ignoreErrors` was added to avoid `Called 'slice' on Laravel collection, but could have been retrieved as a query.` 