### PR TITLE
[v14] Fix Called 'slice' on collection, instead of query

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Called 'slice' on Laravel collection, but could have been retrieved as a query\\.$#"
-			count: 1
-			path: src/Drivers/Database.php

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -30,17 +30,10 @@ class Database implements AuditDriver
     public function prune(Auditable $model): bool
     {
         if (($threshold = $model->getAuditThreshold()) > 0) {
-            $forRemoval = $model->audits()
-                ->latest()
-                ->get()
-                ->slice($threshold)
-                ->pluck('id');
-
-            if (! $forRemoval->isEmpty()) {
-                return $model->audits()
-                    ->whereIn('id', $forRemoval)
-                    ->delete() > 0;
-            }
+            return $model->audits()
+              ->latest()
+              ->offset($threshold)->limit(PHP_INT_MAX)
+              ->delete() > 0;
         }
 
         return false;


### PR DESCRIPTION
Discussion started in https://github.com/owen-it/laravel-auditing/pull/811#discussion_r1149698599
>if we have $threshold = 1000 and audits are 1001, we brings to memory 1001 colection and slice just last one for delete, even if it is less than a 1000, the data is always brought to memory

Maybe no one uses a threshold this big, so, i have another solution
```php
if (($threshold = $model->getAuditThreshold()) > 0) {
    $forRemoval = $model->audits()
        ->latest()
        ->offset($threshold)->limit(PHP_INT_MAX)
        ->pluck('id');

    if (!$forRemoval->isEmpty()) {
        return $model->audits()
            ->whereIn('id', $forRemoval)
            ->delete() > 0;
    }
}
```
