### PR TITLE
[V14] Fix preg_match() Passing null to parameter 2

### DIFF
--- a/src/Concerns/GathersDataToAudit.php
+++ b/src/Concerns/GathersDataToAudit.php
@@ -161,7 +161,7 @@ trait GathersDataToAudit
 
             $auditableEventRegex = sprintf('/%s/', preg_replace('/\*+/', '.*', $auditableEvent));
 
-            if (preg_match($auditableEventRegex, $event)) {
+            if (preg_match($auditableEventRegex, (string) $event)) {
                 return is_int($key) ? sprintf('get%sEventAttributes', ucfirst($event)) : $value;
             }
         }


### PR DESCRIPTION
I'm testing V14 and i'm getting
`preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated`
With this PR everything works again