### PR TITLE
Include Attribute Mutator on Audit Formatting

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -131,7 +131,7 @@ trait Audit
             return $model->mutateAttribute($key, $value);
         }
 
-        if ($model->hasAttributeMutator($key)) {
+        if (method_exists($model, 'hasAttributeMutator') && $model->hasAttributeMutator($key)) {
             return $model->mutateAttributeMarkedAttribute($key, $value);
         }
 

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -131,6 +131,10 @@ trait Audit
             return $model->mutateAttribute($key, $value);
         }
 
+        if ($model->hasAttributeMutator($key)) {
+            return $model->mutateAttributeMarkedAttribute($key, $value);
+        }
+
         if (array_key_exists(
             $key,
             $model->getCasts()

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -192,7 +192,7 @@ class AuditingTest extends AuditingTestCase
         ], $audit->old_values, true);
 
         self::Assert()::assertArraySubset([
-            'content'      => 'First step: install the laravel-auditing package.',
+            'content'      => Article::contentMutate('First step: install the laravel-auditing package.'),
             'published_at' => $now->toDateTimeString(),
             'reviewed'     => 1,
         ], $audit->new_values, true);

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -12,6 +12,8 @@ class Article extends Model implements Auditable
     use \OwenIt\Auditing\Auditable;
     use SoftDeletes;
 
+    protected $laravel_version;
+
     /**
      * {@inheritdoc}
      */
@@ -72,8 +74,17 @@ class Article extends Model implements Auditable
     public function content(): Attribute
     {
         return new Attribute(
-            get: fn ($value) => $value,
-            set: fn ($value) => ucwords($value),
+            function ($value) { return $value; },
+            function ($value) { return ucwords($value); }
         );
+    }
+
+    public static function contentMutate($value)
+    {
+        if (! method_exists(self::class, 'hasAttributeMutator')) {
+            return $value;
+        }
+
+        return ucwords($value);
     }
 }

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -2,6 +2,7 @@
 
 namespace OwenIt\Auditing\Tests\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use OwenIt\Auditing\Contracts\Auditable;
@@ -61,5 +62,18 @@ class Article extends Model implements Auditable
     public function getTitleAttribute(string $value): string
     {
         return strtoupper($value);
+    }
+
+    /**
+     * Uppercase Content accessor.
+     *
+     * @return Attribute
+     */
+    public function content(): Attribute
+    {
+        return new Attribute(
+            get: fn ($value) => $value,
+            set: fn ($value) => ucwords($value),
+        );
     }
 }

--- a/tests/Unit/AuditTest.php
+++ b/tests/Unit/AuditTest.php
@@ -44,7 +44,7 @@ class AuditTest extends AuditingTestCase
             'user_id'          => null,
             'user_type'        => null,
             'new_title'        => 'How To Audit Eloquent Models',
-            'new_content'      => 'First step: install the laravel-auditing package.',
+            'new_content'      => 'First Step: Install The Laravel-auditing Package.',
             'new_published_at' => $now->toDateTimeString(),
             'new_reviewed'     => 1,
             'new_id'           => 1,
@@ -95,7 +95,7 @@ class AuditTest extends AuditingTestCase
             'user_created_at'  => $user->created_at->toDateTimeString(),
             'user_updated_at'  => $user->updated_at->toDateTimeString(),
             'new_title'        => 'How To Audit Eloquent Models',
-            'new_content'      => 'First step: install the laravel-auditing package.',
+            'new_content'      => 'First Step: Install The Laravel-auditing Package.',
             'new_published_at' => $now->toDateTimeString(),
             'new_reviewed'     => 1,
             'new_id'           => 1,
@@ -141,7 +141,7 @@ class AuditTest extends AuditingTestCase
         $this->assertInstanceOf(DateTimeInterface::class, $audit->getDataValue('new_published_at'));
 
         // Original value
-        $this->assertSame('First step: install the laravel-auditing package.', $audit->getDataValue('new_content'));
+        $this->assertSame('First Step: Install The Laravel-auditing Package.', $audit->getDataValue('new_content'));
         $this->assertSame('Sanchez', $audit->getDataValue('user_last_name'));
 
         // Invalid value
@@ -307,7 +307,7 @@ class AuditTest extends AuditingTestCase
                 'new' => 'HOW TO AUDIT ELOQUENT MODELS',
             ],
             'content'      => [
-                'new' => 'First step: install the laravel-auditing package.',
+                'new' => 'First Step: Install The Laravel-auditing Package.',
             ],
             'published_at' => [
                 'new' => $audit->getSerializedDate($now),
@@ -345,7 +345,7 @@ class AuditTest extends AuditingTestCase
                 "new" => "HOW TO AUDIT ELOQUENT MODELS"
             ],
             "content" => [
-                "new" => "First step: install the laravel-auditing package."
+                "new" => "First Step: Install The Laravel-auditing Package."
             ],
             "published_at" => [
                 "new" => "$serializedDate"

--- a/tests/Unit/AuditTest.php
+++ b/tests/Unit/AuditTest.php
@@ -44,7 +44,7 @@ class AuditTest extends AuditingTestCase
             'user_id'          => null,
             'user_type'        => null,
             'new_title'        => 'How To Audit Eloquent Models',
-            'new_content'      => 'First Step: Install The Laravel-auditing Package.',
+            'new_content'      => Article::contentMutate('First step: install the laravel-auditing package.'),
             'new_published_at' => $now->toDateTimeString(),
             'new_reviewed'     => 1,
             'new_id'           => 1,
@@ -95,7 +95,7 @@ class AuditTest extends AuditingTestCase
             'user_created_at'  => $user->created_at->toDateTimeString(),
             'user_updated_at'  => $user->updated_at->toDateTimeString(),
             'new_title'        => 'How To Audit Eloquent Models',
-            'new_content'      => 'First Step: Install The Laravel-auditing Package.',
+            'new_content'      => Article::contentMutate('First step: install the laravel-auditing package.'),
             'new_published_at' => $now->toDateTimeString(),
             'new_reviewed'     => 1,
             'new_id'           => 1,
@@ -141,7 +141,7 @@ class AuditTest extends AuditingTestCase
         $this->assertInstanceOf(DateTimeInterface::class, $audit->getDataValue('new_published_at'));
 
         // Original value
-        $this->assertSame('First Step: Install The Laravel-auditing Package.', $audit->getDataValue('new_content'));
+        $this->assertSame(Article::contentMutate('First step: install the laravel-auditing package.'), $audit->getDataValue('new_content'));
         $this->assertSame('Sanchez', $audit->getDataValue('user_last_name'));
 
         // Invalid value
@@ -307,7 +307,7 @@ class AuditTest extends AuditingTestCase
                 'new' => 'HOW TO AUDIT ELOQUENT MODELS',
             ],
             'content'      => [
-                'new' => 'First Step: Install The Laravel-auditing Package.',
+                'new' => Article::contentMutate('First step: install the laravel-auditing package.'),
             ],
             'published_at' => [
                 'new' => $audit->getSerializedDate($now),
@@ -345,7 +345,7 @@ class AuditTest extends AuditingTestCase
                 "new" => "HOW TO AUDIT ELOQUENT MODELS"
             ],
             "content" => [
-                "new" => "First Step: Install The Laravel-auditing Package."
+                "new" => Article::contentMutate('First step: install the laravel-auditing package.')
             ],
             "published_at" => [
                 "new" => "$serializedDate"

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -409,7 +409,7 @@ class AuditableTest extends AuditingTestCase
             'old_values'     => [],
             'new_values'     => [
                 'title'        => 'How To Audit Eloquent Models',
-                'content'      => 'First step: install the laravel-auditing package.',
+                'content'      => Article::contentMutate('First step: install the laravel-auditing package.'),
                 'reviewed'     => 1,
                 'published_at' => $now->toDateTimeString(),
             ],
@@ -469,7 +469,7 @@ class AuditableTest extends AuditingTestCase
             'old_values'     => [],
             'new_values'     => [
                 'title'        => 'How To Audit Eloquent Models',
-                'content'      => 'First step: install the laravel-auditing package.',
+                'content'      => Article::contentMutate('First step: install the laravel-auditing package.'),
                 'reviewed'     => 1,
                 'published_at' => $now->toDateTimeString(),
             ],
@@ -552,7 +552,7 @@ class AuditableTest extends AuditingTestCase
             'old_values'     => [],
             'new_values'     => [
                 'title'   => 'How To Audit Eloquent Models',
-                'content' => 'First step: install the laravel-auditing package.',
+                'content' => Article::contentMutate('First step: install the laravel-auditing package.'),
             ],
             'event'                 => 'created',
             'auditable_id'          => null,
@@ -1246,7 +1246,7 @@ class AuditableTest extends AuditingTestCase
                 // Expectation when transitioning with new values
                 [
                     'title'   => 'NULLAM EGESTAS INTERDUM ELEIFEND.',
-                    'content' => 'Morbi consectetur laoreet sem, eu tempus odio tempor id.',
+                    'content' => Article::contentMutate('Morbi consectetur laoreet sem, eu tempus odio tempor id.'),
                 ],
             ],
 
@@ -1272,13 +1272,13 @@ class AuditableTest extends AuditingTestCase
                 // Expectation when transitioning with old values
                 [
                     'title'   => 'VIVAMUS A URNA ET LOREM FAUCIBUS MALESUADA NEC NEC MAGNA.',
-                    'content' => 'Mauris ipsum erat, semper non quam vel, sodales tincidunt ligula.',
+                    'content' => Article::contentMutate('Mauris ipsum erat, semper non quam vel, sodales tincidunt ligula.'),
                 ],
 
                 // Expectation when transitioning with new values
                 [
                     'title'   => 'NULLAM EGESTAS INTERDUM ELEIFEND.',
-                    'content' => 'Morbi consectetur laoreet sem, eu tempus odio tempor id.',
+                    'content' => Article::contentMutate('Morbi consectetur laoreet sem, eu tempus odio tempor id.'),
                 ],
             ],
 
@@ -1301,7 +1301,7 @@ class AuditableTest extends AuditingTestCase
                 // Expectation when transitioning with old values
                 [
                     'title'   => 'VIVAMUS A URNA ET LOREM FAUCIBUS MALESUADA NEC NEC MAGNA.',
-                    'content' => 'Mauris ipsum erat, semper non quam vel, sodales tincidunt ligula.',
+                    'content' => Article::contentMutate('Mauris ipsum erat, semper non quam vel, sodales tincidunt ligula.'),
                 ],
 
                 // Expectation when transitioning with new values


### PR DESCRIPTION
## Issue

This pull request addresses the issue of the Audit functionality in the Laravel framework failing to include attribute accessors  during the formatting process. 

## Solution

To solve this issue, I have made modifications to the Audit functionality. The changes now include attribute accessors  when formatting the data. This ensures that any custom formatting defined through attribute accessors is properly considered.

Related Issue #828 

Checklist
- [x] Tests have been added to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
