### PR TITLE
Update return value of Auditor->execute so that it works for PHP Version 8.1.19

### DIFF
--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -55,7 +55,7 @@ class Auditor extends Manager implements Contracts\Auditor
     /**
      * {@inheritdoc}
      */
-    public function execute(Auditable $model)
+    public function execute(Auditable $model): void
     {
         if (!$model->readyForAuditing()) {
             return;


### PR DESCRIPTION
This error is returned if return type void is not provided using  PHP Version > 8.1.19:

Declaration of OwenIt\Auditing\Auditor::execute(OwenIt\Auditing\Contracts\Auditable $model) must be compatible with OwenIt\Auditing\Contracts\Auditor::execute(OwenIt\Auditing\Contracts\Auditable $model): void