### PR TITLE
fix FQCN and add eloquent method to interface

### DIFF
--- a/src/Contracts/Audit.php
+++ b/src/Contracts/Audit.php
@@ -5,6 +5,14 @@ namespace OwenIt\Auditing\Contracts;
 interface Audit
 {
     /**
+     * Create a new Eloquent query builder for the model.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>|static
+     */
+    public function newEloquentBuilder($query);
+    
+    /**
      * Get the current connection name for the model.
      *
      * @return string|null

--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -9,7 +9,7 @@ interface Auditable
     /**
      * Auditable Model audits.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<OwenIt\Auditing\Contracts\Audit>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\OwenIt\Auditing\Contracts\Audit>
      */
     public function audits(): MorphMany;
 


### PR DESCRIPTION
it stops phpstan from reporting this:
```
Internal error: Internal error: Method newEloquentBuilder() was not found in reflection of class
     OwenIt\Auditing\Contracts\Audit. in file
     Controller.php
     Run PHPStan with -v option and post the stack trace to:
     https://github.com/phpstan/phpstan/issues/new?template=Bug_report.yaml
     Child process error (exit code 1):
```