### PR TITLE
Fix incorrect namespace in PHPDoc return

### DIFF
--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -9,7 +9,7 @@ interface Auditable
     /**
      * Auditable Model audits.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<OwenIt\Auditing\Contracts\Audit>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\OwenIt\Auditing\Contracts\Audit>
      */
     public function audits(): MorphMany;
 


### PR DESCRIPTION
Hi,

PHPStan started failing with "Class OwenIt\Auditing\Contracts\OwenIt\Auditing\Contracts\Audit was not found while trying to analyse it" due to the missing leading slash on the PHPDoc @return in `\OwenIt\Auditing\Contracts\Auditable::audits()`