### PR TITLE
Make UrlResolver resolve the proper command line used instead of "console"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,4 +58,6 @@ jobs:
           composer update --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: |
+          vendor/bin/phpunit
+          vendor/bin/phpunit tests/Unit/AuditTest.php --group command-line-url-resolver

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,15 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+    <groups>
+        <exclude>
+            <!--
+                Group tests that are run with specific command line arguments to ensure they're
+                properly tracked in audits. See \OwenIt\Auditing\Resolvers\UrlResolver.
+            -->
+            <group>command-line-url-resolver</group>
+        </exclude>
+    </groups>
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src</directory>

--- a/src/Resolvers/UrlResolver.php
+++ b/src/Resolvers/UrlResolver.php
@@ -14,9 +14,19 @@ class UrlResolver implements \OwenIt\Auditing\Contracts\Resolver
     public static function resolve(Auditable $auditable): string
     {
         if (App::runningInConsole()) {
-            return 'console';
+            return self::resolveCommandLine();
         }
 
         return Request::fullUrl();
+    }
+
+    public static function resolveCommandLine(): string
+    {
+        $command = \Request::server('argv', null);
+        if (is_array($command)) {
+            return implode(' ', $command);
+        }
+
+        return 'console';
     }
 }

--- a/tests/AuditingTestCase.php
+++ b/tests/AuditingTestCase.php
@@ -69,9 +69,9 @@ class AuditingTestCase extends TestCase
     /**
      * Locate the Illuminate testing class. It changed namespace with v7
      * @see https://readouble.com/laravel/7.x/en/upgrade.html
-     * @return string
+     * @return class-string<\Illuminate\Foundation\Testing\Assert|\Illuminate\Testing\Assert>
      */
-    public static function Assert()
+    public static function Assert(): string
     {
         if (class_exists('Illuminate\Foundation\Testing\Assert')) {
             return '\Illuminate\Foundation\Testing\Assert';

--- a/tests/Unit/AuditTest.php
+++ b/tests/Unit/AuditTest.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use OwenIt\Auditing\Encoders\Base64Encoder;
 use OwenIt\Auditing\Models\Audit;
 use OwenIt\Auditing\Redactors\LeftRedactor;
+use OwenIt\Auditing\Resolvers\UrlResolver;
 use OwenIt\Auditing\Tests\Models\Article;
 use OwenIt\Auditing\Tests\Models\User;
 
@@ -35,7 +36,7 @@ class AuditTest extends AuditingTestCase
         self::Assert()::assertArraySubset([
             'audit_id'         => 1,
             'audit_event'      => 'created',
-            'audit_url'        => 'console',
+            'audit_url'        => UrlResolver::resolveCommandLine(),
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony',
             'audit_tags'       => null,
@@ -82,7 +83,7 @@ class AuditTest extends AuditingTestCase
         self::Assert()::assertArraySubset([
             'audit_id'         => 2,
             'audit_event'      => 'created',
-            'audit_url'        => 'console',
+            'audit_url'        => UrlResolver::resolveCommandLine(),
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony',
             'audit_tags'       => null,
@@ -161,7 +162,7 @@ class AuditTest extends AuditingTestCase
         self::Assert()::assertArraySubset([
             'audit_id'         => 1,
             'audit_event'      => 'created',
-            'audit_url'        => 'console',
+            'audit_url'        => UrlResolver::resolveCommandLine(),
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony',
             'audit_tags'       => null,
@@ -170,6 +171,19 @@ class AuditTest extends AuditingTestCase
             'user_id'          => null,
             'user_type'        => null,
         ], $metadata, true);
+    }
+
+    /**
+     * This test is meant to be run with specific command line "vendor/bin/phpunit tests/Unit/AuditTest.php --group command-line-url-resolver"
+     *
+     * @group command-line-url-resolver
+     * @test
+     */
+    public function itReturnsProperCommandLineInUrlAuditMetadata()
+    {
+        $audit = factory(Article::class)->create()->audits()->first();
+
+        self::Assert()::assertEquals($audit->getMetadata()['audit_url'], 'vendor/bin/phpunit tests/Unit/AuditTest.php --group command-line-url-resolver');
     }
 
     /**
@@ -195,7 +209,7 @@ class AuditTest extends AuditingTestCase
         self::Assert()::assertArraySubset([
             'audit_id'         => 2,
             'audit_event'      => 'created',
-            'audit_url'        => 'console',
+            'audit_url'        => UrlResolver::resolveCommandLine(),
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony',
             'audit_tags'       => null,
@@ -232,7 +246,7 @@ class AuditTest extends AuditingTestCase
             'audit_updated_at' => $updated_at,
             'user_id' => null,
             'user_type' => null,
-            'audit_url' => 'console',
+            'audit_url' => UrlResolver::resolveCommandLine(),
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony'
         ];
@@ -271,7 +285,7 @@ class AuditTest extends AuditingTestCase
             'audit_updated_at' => $updated_at,
             'user_id' => 1,
             'user_type' => 'OwenIt\\Auditing\\Tests\\Models\\User',
-            'audit_url' => 'console',
+            'audit_url' => UrlResolver::resolveCommandLine(),
             'audit_ip_address' => '127.0.0.1',
             'audit_user_agent' => 'Symfony',
             'user_is_admin' => true,

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -15,6 +15,7 @@ use OwenIt\Auditing\Exceptions\AuditingException;
 use OwenIt\Auditing\Models\Audit;
 use OwenIt\Auditing\Redactors\LeftRedactor;
 use OwenIt\Auditing\Redactors\RightRedactor;
+use OwenIt\Auditing\Resolvers\UrlResolver;
 use OwenIt\Auditing\Tests\Models\ApiModel;
 use OwenIt\Auditing\Tests\Models\Article;
 use OwenIt\Auditing\Tests\Models\ArticleExcludes;
@@ -418,7 +419,7 @@ class AuditableTest extends AuditingTestCase
             'auditable_type'        => Article::class,
             $morphPrefix . '_id'    => null,
             $morphPrefix . '_type'  => null,
-            'url'                   => 'console',
+            'url'                   => UrlResolver::resolveCommandLine(),
             'ip_address'            => '127.0.0.1',
             'user_agent'            => 'Symfony',
             'tags'                  => null,
@@ -478,7 +479,7 @@ class AuditableTest extends AuditingTestCase
             'auditable_type'        => Article::class,
             $morphPrefix . '_id'    => $id,
             $morphPrefix . '_type'  => $type,
-            'url'                   => 'console',
+            'url'                   => UrlResolver::resolveCommandLine(),
             'ip_address'            => '127.0.0.1',
             'user_agent'            => 'Symfony',
             'tags'                  => null,
@@ -559,7 +560,7 @@ class AuditableTest extends AuditingTestCase
             'auditable_type'        => Article::class,
             $morphPrefix . '_id'    => null,
             $morphPrefix . '_type'  => null,
-            'url'                   => 'console',
+            'url'                   => UrlResolver::resolveCommandLine(),
             'ip_address'            => '127.0.0.1',
             'user_agent'            => 'Symfony',
             'tags'                  => null,


### PR DESCRIPTION
Hello,

I've had ambiguous audits in the past where we couldn't determinate from which of our scheduled command these modifications were coming from because everything is "console", so the debugging experience were not ideal.

To improve the situation I implemented a custom way to retrieve the proper command line used while generating the audit, this works great for us. 

![image](https://github.com/owen-it/laravel-auditing/assets/1524501/3d177b40-6c24-4930-a13e-14a04d7c971e)

So I decided to contribute it.

*Note*: Since the url metadata is now non deterministic in tests because of various possible ways to run the tests (arguments, options, paths, etc.), I've decided to expose the command line resolving logic to make use of it in tests that are not meant to test this feature specifically. 
And then introduce a test that is meant to run with a specific command line and thus expect a deterministic output. This one is actually testing the logic.

