### PR TITLE
Read Audit implementation from MorphMany

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -14,9 +14,7 @@ class Database implements AuditDriver
      */
     public function audit(Auditable $model): ?Audit
     {
-        $implementation = Config::get('audit.implementation', \OwenIt\Auditing\Models\Audit::class);
-
-        return call_user_func([$implementation, 'create'], $model->toAudit());
+        return call_user_func([$model->audits()->getModel()::class, 'create'], $model->toAudit());
     }
 
     /**


### PR DESCRIPTION
To allow a different Audit implementation **per model** the implementation should be deducted from the MorphMany given by the Auditable::audits method.

This will allow having a main Audit implementation (which defaults to `OwenIt\Auditing\Models\Audit`), but also have a different implementation once the Auditable::audits method is overwritten.

Example:
```php
class MyAuditable extends Model implements AuditableContract
{
    use Auditable;

    /**
     * @return MorphMany<AuditOfMyAuditableModel>
     */
    public function audits(): MorphMany
    {
        return $this->morphMany(
            AuditOfMyAuditableModel::class,
            'auditable',
        );
    }
```