### PR TITLE
Avoid duplicate data on detach, attach, sync

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -736,8 +736,8 @@ trait Auditable
      */
     private function dispatchRelationAuditEvent($relationName, $event, $old, $new)
     {
-        $this->auditCustomOld[$relationName] = $old->toArray();
-        $this->auditCustomNew[$relationName] = $new->toArray();
+        $this->auditCustomOld[$relationName] = $old->diff($new)->toArray();
+        $this->auditCustomNew[$relationName] = $new->diff($old)->toArray();
 
         if (
             empty($this->auditCustomOld[$relationName]) &&


### PR DESCRIPTION
Only the `added`/`removed` records in the pivots are audited, and in the case that there are no changes and `'audit.empty_values'` is false the audit would not be recorded

The current behavior is that if there are no changes, `old` and `new` add all the same existing records