### PR TITLE
Make queued auditing opt-in

### DIFF
--- a/src/AuditableObserver.php
+++ b/src/AuditableObserver.php
@@ -105,7 +105,7 @@ class AuditableObserver
             return;
         }
 
-        if (!Config::get('audit.queue.enable', true)) {
+        if (!Config::get('audit.queue.enable', false)) {
             return Auditor::execute($model);
         }
 


### PR DESCRIPTION
The previous PR #881 made the default behavior opt-out, while I think we actually want it to be opt-in to avoid breaking changes.

For some more context, I am updating composer packages and our test cases were failing that were concerned with auditing. After some digging, I realized I had to copy over the updates to config/audit.php and ensure that we had `'audit.queue.enabled'` set to `false`.

With the change proposed in this PR, there's no need to copy over the configuration (which isn't always obvious), it will just work exactly as it did previously without updating the configuration.