### PR TITLE
Disable queue by default

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -166,7 +166,7 @@ return [
     */
 
     'queue' => [
-        'enable'     => true,
+        'enable'     => false,
         'connection' => 'sync',
         'queue'      => 'default',
         'delay'      => 0,

--- a/tests/AuditingTestCase.php
+++ b/tests/AuditingTestCase.php
@@ -43,6 +43,7 @@ class AuditingTestCase extends TestCase
         $app['config']->set('audit.resolvers.user_agent', UserAgentResolver::class);
         $app['config']->set('audit.console', true);
         $app['config']->set('audit.empty_values', true);
+        $app['config']->set('audit.queue.enable', true);
     }
 
     /**


### PR DESCRIPTION
Apparently `queue` causes unexpected problems, it would be safer if it were disabled by default

https://github.com/owen-it/laravel-auditing/pull/882#issuecomment-1871250510
>100%. The default value should also be false in `config/audit.php` 
>There is a breaking change currently re queues and this PR doesn't really prevent the issue happening.
>See: https://github.com/owen-it/laravel-auditing/issues/890