### PR TITLE
feat (Auditable): customized relationship for Attach, Detach and Sync

### DIFF
--- a/tests/database/migrations/0000_00_00_000003_create_categories_test_table.php
+++ b/tests/database/migrations/0000_00_00_000003_create_categories_test_table.php
@@ -21,6 +21,7 @@ class CreateCategoriesTestTable extends Migration
 
         Schema::create('model_has_categories', function (Blueprint $table) {
             $table->string('model_type');
+            $table->string('pivot_type')->nullable();
             $table->unsignedBigInteger('category_id');
             $table->unsignedBigInteger('model_id');
             $table->timestamps();


### PR DESCRIPTION
Hello guys. 

In my API I have a situation where I need to provide a BelongsToMany relationship with some conditions to Audit Attach, Detach and Sync.

This situation occurs because my pivot table has many pivot columns that need to be conditioned when I do an Attach/Detach/Sync.

Nowadays I can't do this, as these methods only accept the name of the relationship (without conditions). So I made this PR with a new optional parameter `$relationship`.

Example use case:

![image](https://github.com/owen-it/laravel-auditing/assets/42422976/3c16afcc-fb63-4f6d-b614-1b08601a5a76)

In this case, I just want to sync the serviceTypes relationship in my pivot table, where the pivot columns match the respective company_id and tenancy_id values. The other data in the pivot table remained unchanged.
