### PR TITLE
Support 404labfr/laravel-impersonate

### DIFF
--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -13,6 +13,15 @@ class UserResolver implements \OwenIt\Auditing\Contracts\UserResolver
      */
     public static function resolve()
     {
+        // supports https://github.com/404labfr/laravel-impersonate
+        if (app()->bound('impersonate')) {
+            /** @var \Lab404\Impersonate\Services\ImpersonateManager */
+            $impersonate = app('impersonate');
+            if ($impersonate->isImpersonating()) {
+                return $impersonate->findUserById($impersonate->getImpersonatorId());
+            }
+        }
+
         $guards = Config::get('audit.user.guards', [
             \config('auth.defaults.guard')
         ]);


### PR DESCRIPTION
Closes #903

>Using [404labfr/laravel-impersonate](https://github.com/404labfr/laravel-impersonate) in [owen-it/laravel-auditing](https://github.com/owen-it/laravel-auditing) saves the impersonated user instead of the impersonating user