### PR TITLE
Add config to allow records array values

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -108,6 +108,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Allowed Array Values
+    |--------------------------------------------------------------------------
+    |
+    | Should the array values be audited?
+    |
+    | By default, array values are not allowed. This is to prevent performance
+    | issues when storing large amounts of data. You can override this by
+    | setting allow_array_values to true.
+    */
+    'allowed_array_values' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Audit Timestamps
     |--------------------------------------------------------------------------
     |

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -125,7 +125,7 @@ trait Auditable
         foreach ($attributes as $attribute => $value) {
             // Apart from null, non scalar values will be excluded
             if (
-                is_array($value) ||
+                (is_array($value) && !Config::get('audit.allowed_array_values', false)) ||
                 (is_object($value) &&
                     !method_exists($value, '__toString') &&
                     !($value instanceof \UnitEnum))
@@ -365,8 +365,8 @@ trait Auditable
      *
      */
     protected function resolveUser()
-    {   
-        if (! empty($this->preloadedResolverData['user'] ?? null)) {
+    {
+        if (!empty($this->preloadedResolverData['user'] ?? null)) {
             return $this->preloadedResolverData['user'];
         }
 
@@ -417,7 +417,7 @@ trait Auditable
         $this->preloadedResolverData = $this->runResolvers();
 
         $user = $this->resolveUser();
-        if (!empty ($user)) {
+        if (!empty($user)) {
             $this->preloadedResolverData['user'] = $user;
         }
 
@@ -509,11 +509,11 @@ trait Auditable
     public function getAuditEvents(): array
     {
         return $this->auditEvents ?? Config::get('audit.events', [
-                'created',
-                'updated',
-                'deleted',
-                'restored',
-            ]);
+            'created',
+            'updated',
+            'deleted',
+            'restored',
+        ]);
     }
 
     /**

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -968,12 +968,11 @@ class AuditableTest extends AuditingTestCase
         ]);
 
         $model = Article::first();
-        
+
         $this->assertEquals($model->published_at, $originalStart);
 
         $model->published_at = new Carbon('2022-01-01 12:30:00');
         $model->save();
-        
         $audit = $model->audits->last();
         $audit->auditable_id = $model->id;
 
@@ -1309,5 +1308,91 @@ class AuditableTest extends AuditingTestCase
                 [],
             ],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function itWorksWhenConfigAllowedArrayValueIsTrue()
+    {
+        $this->app['config']->set('audit.allowed_array_values', true);
+
+        $model = factory(Article::class)->make([
+            'title'        => 'How To Audit Eloquent Models',
+            'content'      => 'First step: install the laravel-auditing package.',
+            'reviewed'     => 1,
+            'images' => [
+                'https://example.com/image1.jpg',
+                'https://example.com/image2.jpg',
+            ]
+        ]);
+
+        $model->setAuditEvent('created');
+
+        $auditData = $model->toAudit();
+
+        $morphPrefix = config('audit.user.morph_prefix', 'user');
+        self::Assert()::assertArraySubset([
+            'old_values'     => [],
+            'new_values'     => [
+                'title'        => 'How To Audit Eloquent Models',
+                'content'      => Article::contentMutate('First step: install the laravel-auditing package.'),
+                'reviewed'     => 1,
+                'images'       => [
+                    'https://example.com/image1.jpg',
+                    'https://example.com/image2.jpg',
+                ],
+            ],
+            'event'                 => 'created',
+            'auditable_id'          => null,
+            'auditable_type'        => Article::class,
+            $morphPrefix . '_id'    => null,
+            $morphPrefix . '_type'  => null,
+            'url'                   => UrlResolver::resolveCommandLine(),
+            'ip_address'            => '127.0.0.1',
+            'user_agent'            => 'Symfony',
+            'tags'                  => null,
+        ], $auditData, true);
+    }
+
+    /**
+     * @test
+     */
+    public function itWorksWhenConfigAllowedArrayValueIsFalse()
+    {
+        $this->app['config']->set('audit.allowed_array_values', false);
+
+        $model = factory(Article::class)->make([
+            'title'        => 'How To Audit Eloquent Models',
+            'content'      => 'First step: install the laravel-auditing package.',
+            'reviewed'     => 1,
+            'images' => [
+                'https://example.com/image1.jpg',
+                'https://example.com/image2.jpg',
+            ]
+        ]);
+
+        $model->setAuditEvent('created');
+
+        $auditData = $model->toAudit();
+
+        $morphPrefix = config('audit.user.morph_prefix', 'user');
+        self::Assert()::assertArraySubset([
+            'old_values'     => [],
+            'new_values'     => [
+                'title'        => 'How To Audit Eloquent Models',
+                'content'      => Article::contentMutate('First step: install the laravel-auditing package.'),
+                'reviewed'     => 1,
+            ],
+            'event'                 => 'created',
+            'auditable_id'          => null,
+            'auditable_type'        => Article::class,
+            $morphPrefix . '_id'    => null,
+            $morphPrefix . '_type'  => null,
+            'url'                   => UrlResolver::resolveCommandLine(),
+            'ip_address'            => '127.0.0.1',
+            'user_agent'            => 'Symfony',
+            'tags'                  => null,
+        ], $auditData, true);
     }
 }

--- a/tests/database/migrations/0000_00_00_000003_create_articles_test_table.php
+++ b/tests/database/migrations/0000_00_00_000003_create_articles_test_table.php
@@ -21,6 +21,7 @@ class CreateArticlesTestTable extends Migration
             $table->timestamp('published_at')->nullable();
             $table->json('config')->nullable();
             $table->string('price')->nullable();
+            $table->json('images')->nullable();
             $table->timestamps();
             $table->softDeletes();
         });


### PR DESCRIPTION
In projects utilizing MongoDB as the database, data is commonly stored in the form of arrays and objects. However, non-scalar values are not allowed to be recorded in this packages. 

Therefore, I have added a new config to provide users with the option to audit array values.

Issue: #596 