### PR TITLE
Add `withoutAuditing()` callback method to temporarily disable auditing for one class

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -537,6 +537,26 @@ trait Auditable
     }
 
     /**
+     * Execute a callback while auditing is disabled.
+     *
+     * @param callable $callback
+     *
+     * @return mixed
+     */
+    public static function withoutAuditing(callable $callback)
+    {
+        $auditingDisabled = static::$auditingDisabled;
+
+        static::disableAuditing();
+
+        try {
+            return $callback();
+        } finally {
+            static::$auditingDisabled = $auditingDisabled;
+        }
+    }
+
+    /**
      * Determine whether auditing is enabled.
      *
      * @return bool

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -433,6 +433,29 @@ class AuditingTest extends AuditingTestCase
 
     /**
      * @test
+     */
+    public function itDisablesAndEnablesAuditingBackAgainViaWithoutAuditingMethod()
+    {
+        // Auditing is enabled by default
+        $this->assertFalse(Article::$auditingDisabled);
+
+        Article::withoutAuditing(function () {
+            factory(Article::class)->create();
+        });
+
+        $this->assertSame(1, Article::count());
+        $this->assertSame(0, Audit::count());
+
+        $this->assertFalse(Article::$auditingDisabled);
+
+        factory(Article::class)->create();
+
+        $this->assertSame(2, Article::count());
+        $this->assertSame(1, Audit::count());
+    }
+
+    /**
+     * @test
      * @return void
      */
     public function itHandlesJsonColumnsCorrectly()

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -37,6 +37,40 @@ class AuditableTest extends AuditingTestCase
     }
 
     /**
+     * @group Auditable::withoutAuditing
+     * @test
+     */
+    public function itWillRunCallbackWithAuditingDisabled()
+    {
+        $this->assertFalse(Article::$auditingDisabled);
+
+        $result = Article::withoutAuditing(function () {
+            $this->assertTrue(Article::$auditingDisabled);
+            $this->assertFalse(ArticleExcludes::$auditingDisabled);
+
+            return 'result';
+        });
+
+        $this->assertFalse(Article::$auditingDisabled);
+        $this->assertSame('result', $result);
+    }
+
+    /**
+     * @group Auditable::withoutAuditing
+     * @test
+     */
+    public function itWillRunCallbackThenRestoreAuditingDisabled()
+    {
+        Article::$auditingDisabled = true;
+
+        Article::withoutAuditing(function () {
+            $this->assertTrue(Article::$auditingDisabled);
+        });
+
+        $this->assertTrue(Article::$auditingDisabled);
+    }
+
+    /**
      * @group Auditable::isAuditingEnabled
      * @test
      */


### PR DESCRIPTION
## Summary

Similar to Laravel's `Model::withoutEvents()` method, allow running Eloquent queries on a given model class inside a callback:

```php
User::withoutAuditing(function () use ($user, $inputs, $additional) {
    // no audit
    $user->update($inputs);

    // this _will_ be audited if the Profile class is Auditable
    $user->profile()->updateOrCreate([], $additional);
});
```

Only the `{class}::withoutAuditing()` class will have auditing disabled, so additional model classes need their own call. e.g.,

```php
User::withoutAuditing(fn () => $user->update($inputs));
Profile::withoutAuditing(fn () => $user->profile()->updateOrCreate([], $additional));
```

---

1. It's wrapped in `try` / `finally` to handle restoring auditing after Eloquent possibly throws `QueryException`.
2. If auditing is already disabled, that setting will be kept. i.e., don't call `enableAuditing()`

## Links

* https://laravel.com/docs/11.x/eloquent#muting-events
* https://github.com/laravel/framework/blob/6c9cbc9ba0437bcfe54609ae0af312feefc7e309/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php#L426-L441
* https://github.com/laravel/framework/blob/e307d111c22066ef614a112664724b4db4956968/src/Illuminate/Support/Traits/Localizable.php#L16 Another example using the same design pattern.