### PR TITLE
Fix link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Contributions are always welcome, but to keep things organized, keep in mind the following rules.
 
 # Bug Reports
-When reporting a bug in the Laravel Auditing package, make sure you follow the [rules](http://laravel-auditing.com/docs/master/problems).
+When reporting a bug in the Laravel Auditing package, make sure you follow the [rules](https://laravel-auditing.com/guide/community/problems.html).
 
 Failure to do so, will result in a closed ticket.
 


### PR DESCRIPTION
The issue form links to a specific commit (https://github.com/owen-it/laravel-auditing/blob/4afff44bd0284ca213b762a75d29498e67f24801/CONTRIBUTING.md), not master, but I don't know if that's automatically updated.