### PR TITLE
Avoid only using `id` as audit model primary key

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -77,7 +77,7 @@ trait Audit
 
         // Metadata
         $this->data = [
-            'audit_id'         => $this->id,
+            'audit_id'         => $this->getKey(),
             'audit_event'      => $this->event,
             'audit_tags'       => $this->tags,
             'audit_created_at' => $this->serializeDate($this->{$this->getCreatedAtColumn()}),

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -23,17 +23,10 @@ class Database implements AuditDriver
     public function prune(Auditable $model): bool
     {
         if (($threshold = $model->getAuditThreshold()) > 0) {
-            $forRemoval = $model->audits()
+            return $model->audits()
                 ->latest()
-                ->get()
-                ->slice($threshold)
-                ->pluck('id');
-
-            if (!$forRemoval->isEmpty()) {
-                return $model->audits()
-                    ->whereIn('id', $forRemoval)
-                    ->delete() > 0;
-            }
+                ->offset($threshold)->limit(PHP_INT_MAX)
+                ->delete() > 0;
         }
 
         return false;


### PR DESCRIPTION
https://github.com/owen-it/laravel-auditing/blob/f236e42c6cf8ba6264499e205d59d4c0b37d1def/config/audit.php#L16

On custom audit implementation, the model primary key could be different to `id`, like `uuid`

---

Also `threshold prune` brings all the audits to memory before prune
I have my doubts `PHP_INT_MAX` 😕
