### PR TITLE
12.x EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Thank you for choosing OwenIt\LaravelAuditing!
 Version   | Illuminate     | Status                  | PHP Version
 :----------|:---------------|:------------------------|:------------
 13.x      | 7.x.x - 11.x.x | Active support :rocket: | > = 7.3 \| 8.0
-12.x      | 6.x.x - 9.x.x | Active support          | > = 7.3 \| 8.0
+12.x      | 6.x.x - 9.x.x | End of life             | > = 7.3 \| 8.0
 11.x      | 5.8.x - 8.x.x | End of life             | > = 7.3
 10.x      | 5.8.x - 7.x.x | End of life             | > = 7.2.5
 9.x       | 5.8.x - 6.x.x | End of life             | > = 7.1.3


### PR DESCRIPTION
[12.x](https://github.com/owen-it/laravel-auditing/tree/v12) branch has not received changes since [2 years ago](https://github.com/owen-it/laravel-auditing/commit/98f1cfddbc4ed257e5644fe02e97db5674c7571a), and Laravel 9.x  has already reached [end of life](https://laravel.com/docs/9.x/releases#support-policy)
I think the "manpower" should be prioritized for still supported versions

---

On a separate matter I have no knowledge of what was being worked on in [v14-dev](https://github.com/owen-it/laravel-auditing/tree/v14-dev) branch, 
It is quite outdated, and I don't know if all the features were finished
