### PR TITLE
Fix "repository" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Laravel Auditing allows you to keep a history of model changes by simply using a
 
 ## Official Documentation
 
-For more information on how to use the package, please refer to our official documentation available on [laravel-auditing.com](https://laravel-auditing.com) or in the [repository](https://github.com/owen-it/laravel-auditing-doc/blob/main/documentation.md) documentation file. Our documentation provides detailed instructions on how to install and use the package, as well as examples and best practices for auditing in Laravel applications.
+For more information on how to use the package, please refer to our official documentation available on [laravel-auditing.com](https://laravel-auditing.com) or in the [repository](https://github.com/owen-it/laravel-auditing.com/blob/main/docs/guide/documentation.md) documentation file. Our documentation provides detailed instructions on how to install and use the package, as well as examples and best practices for auditing in Laravel applications.
 
 Thank you for choosing OwenIt\LaravelAuditing!
 


### PR DESCRIPTION
## Summary

The official documentation "repository" link is still leading to the old archived repo https://github.com/owen-it/laravel-auditing-doc/. Update to the currently-maintained https://github.com/owen-it/laravel-auditing.com/.