### PR TITLE
Globally disable auditing on `withoutAuditing()`

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -35,6 +35,13 @@ trait Audit
     protected $modified = [];
 
     /**
+     * Is globally auditing disabled?
+     *
+     * @var bool
+     */
+    public static $auditingDisabled = false;
+
+    /**
      * {@inheritdoc}
      */
     public function auditable()

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -256,7 +256,7 @@ trait Auditable
      */
     public function readyForAuditing(): bool
     {
-        if (static::$auditingDisabled) {
+        if (static::$auditingDisabled || Audit::$auditingDisabled) {
             return false;
         }
 
@@ -517,6 +517,16 @@ trait Auditable
     }
 
     /**
+     * Is Auditing disabled.
+     *
+     * @return bool
+     */
+    public static function isAuditingDisabled(): bool
+    {
+        return static::$auditingDisabled || Audit::$auditingDisabled;
+    }
+
+    /**
      * Disable Auditing.
      *
      * @return void
@@ -540,18 +550,21 @@ trait Auditable
      * Execute a callback while auditing is disabled.
      *
      * @param callable $callback
+     * @param bool $globally
      *
      * @return mixed
      */
-    public static function withoutAuditing(callable $callback)
+    public static function withoutAuditing(callable $callback, bool $globally = false)
     {
         $auditingDisabled = static::$auditingDisabled;
 
         static::disableAuditing();
+        Audit::$auditingDisabled = $globally;
 
         try {
             return $callback();
         } finally {
+            Audit::$auditingDisabled = false;
             static::$auditingDisabled = $auditingDisabled;
         }
     }

--- a/tests/Unit/AuditableTest.php
+++ b/tests/Unit/AuditableTest.php
@@ -40,16 +40,35 @@ class AuditableTest extends AuditingTestCase
      * @group Auditable::withoutAuditing
      * @test
      */
+    public function itWillRunCallbackWithModelAuditingDisabled()
+    {
+        $this->assertFalse(Article::$auditingDisabled);
+
+        $result = Article::withoutAuditing(function () {
+            $this->assertTrue(Article::isAuditingDisabled());
+            $this->assertFalse(ApiModel::isAuditingDisabled());
+
+            return 'result';
+        });
+
+        $this->assertFalse(Article::$auditingDisabled);
+        $this->assertSame('result', $result);
+    }
+
+    /**
+     * @group Auditable::withoutAuditing
+     * @test
+     */
     public function itWillRunCallbackWithAuditingDisabled()
     {
         $this->assertFalse(Article::$auditingDisabled);
 
         $result = Article::withoutAuditing(function () {
-            $this->assertTrue(Article::$auditingDisabled);
-            $this->assertFalse(ApiModel::$auditingDisabled);
+            $this->assertTrue(Article::isAuditingDisabled());
+            $this->assertTrue(ApiModel::isAuditingDisabled());
 
             return 'result';
-        });
+        }, true);
 
         $this->assertFalse(Article::$auditingDisabled);
         $this->assertSame('result', $result);


### PR DESCRIPTION
Discussed on  [#917](https://github.com/owen-it/laravel-auditing/pull/917#issuecomment-2133701358)
```php

User::withoutAuditing(function () use ($user, $inputs, $additional) {
    // no audit
    $user->update($inputs);

    // this will not be audited if the Profile class is Auditable
    $user->profile()->updateOrCreate([], $additional);
}, true); // adding true($globally) disables auditing on entire code block
```
**CC:** @derekmd 
