### PR TITLE
Fix php 8.3 deprecation warning

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -35,13 +35,6 @@ trait Audit
     protected $modified = [];
 
     /**
-     * Is globally auditing disabled?
-     *
-     * @var bool
-     */
-    public static $auditingDisabled = false;
-
-    /**
      * {@inheritdoc}
      */
     public function auditable()

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -259,7 +259,7 @@ trait Auditable
      */
     public function readyForAuditing(): bool
     {
-        if (static::$auditingDisabled || Audit::$auditingDisabled) {
+        if (static::$auditingDisabled || Models\Audit::$auditingDisabled) {
             return false;
         }
 
@@ -526,7 +526,7 @@ trait Auditable
      */
     public static function isAuditingDisabled(): bool
     {
-        return static::$auditingDisabled || Audit::$auditingDisabled;
+        return static::$auditingDisabled || Models\Audit::$auditingDisabled;
     }
 
     /**
@@ -562,12 +562,12 @@ trait Auditable
         $auditingDisabled = static::$auditingDisabled;
 
         static::disableAuditing();
-        Audit::$auditingDisabled = $globally;
+        Models\Audit::$auditingDisabled = $globally;
 
         try {
             return $callback();
         } finally {
-            Audit::$auditingDisabled = false;
+            Models\Audit::$auditingDisabled = false;
             static::$auditingDisabled = $auditingDisabled;
         }
     }

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -22,6 +22,13 @@ class Audit extends Model implements \OwenIt\Auditing\Contracts\Audit
     protected $guarded = [];
 
     /**
+     * Is globally auditing disabled?
+     *
+     * @var bool
+     */
+    public static $auditingDisabled = false;
+
+    /**
      * {@inheritdoc}
      */
     protected $casts = [


### PR DESCRIPTION
```
Accessing static trait property OwenIt\Auditing\Audit::$auditingDisabled is deprecated,
it should only be accessed on a class using the trait
```