### PR TITLE
allows for merging excludes into the config exclude list

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -143,6 +143,14 @@ trait Auditable
      */
     public function getAuditExclude(): array
     {
+        if(property_exists($this, 'auditExcludeMerge'))
+        {
+            return array_merge(
+                $this->auditExcludeMerge,
+                Config::get('audit.exclude', [])
+            );
+        }
+
         return $this->auditExclude ?? Config::get('audit.exclude', []);
     }
 

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -143,12 +143,8 @@ trait Auditable
      */
     public function getAuditExclude(): array
     {
-        if(property_exists($this, 'auditExcludeMerge'))
-        {
-            return array_merge(
-                $this->auditExcludeMerge,
-                Config::get('audit.exclude', [])
-            );
+        if ($this->auditExcludeMerge ?? false) {
+            return array_merge($this->auditExclude ?? [], Config::get('audit.exclude', []));
         }
 
         return $this->auditExclude ?? Config::get('audit.exclude', []);


### PR DESCRIPTION
The auditExcludeMerge property overrides the auditExclude property if set, and will be merged into the config's audit.exclude property.