### PR TITLE
Gravitymedianet audit exclude merge feature

### DIFF
--- a/config/audit.php
+++ b/config/audit.php
@@ -88,6 +88,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Global exclusion merge
+    |--------------------------------------------------------------------------
+    |
+    | If set to true, the local model auditExclude array values will be
+    | merged with the config exclude array values instead of replacing 
+    | them.
+    |
+    */
+
+    'exclude_merge' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Empty Values
     |--------------------------------------------------------------------------
     |

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -143,7 +143,10 @@ trait Auditable
      */
     public function getAuditExclude(): array
     {
-        if ($this->auditExcludeMerge ?? false) {
+        if ( 
+            Config::get('audit.exclude_merge', false) || 
+            ($this->auditExcludeMerge ?? false) 
+        ) {
             return array_merge($this->auditExclude ?? [], Config::get('audit.exclude', []));
         }
 

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -143,6 +143,14 @@ trait Auditable
      */
     public function getAuditExclude(): array
     {
+        if(property_exists($this, 'auditExcludeMerge'))
+        {
+            return array_merge(
+                $this->auditExcludeMerge,
+                Config::get('audit.exclude', [])
+            );
+        }
+
         return $this->auditExclude ?? Config::get('audit.exclude', []);
     }
 

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -143,12 +143,8 @@ trait Auditable
      */
     public function getAuditExclude(): array
     {
-        if(property_exists($this, 'auditExcludeMerge'))
-        {
-            return array_merge(
-                $this->auditExcludeMerge,
-                Config::get('audit.exclude', [])
-            );
+        if ($this->auditExcludeMerge ?? false) {
+            return array_merge($this->auditExclude ?? [], Config::get('audit.exclude', []));
         }
 
         return $this->auditExclude ?? Config::get('audit.exclude', []);


### PR DESCRIPTION
Allows for enabling global merging of the config exclude values and any local auditable model's auditExclude values, instead of replacing the global exclude list.