### PR TITLE
PHPStal lvl 0 baseline

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -73,3 +73,6 @@ jobs:
         run: |
           vendor/bin/phpunit
           vendor/bin/phpunit tests/Unit/AuditTest.php --group command-line-url-resolver
+
+      - name: Run PHPStan
+        run: composer analyse

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,12 @@
         "phpunit/phpunit": "^9.6|^10.5|^11.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0|^9.0",
-        "laravel/legacy-factories": "*"
+        "laravel/legacy-factories": "*",
+        "phpstan/phpstan": "^1.12",
+        "phpstan/phpstan-phpunit": "^1.4",
+        "larastan/larastan": "^2.9",
+        "phpstan/phpstan-strict-rules": "^1.6",
+        "phpstan/phpstan-mockery": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -73,6 +78,9 @@
                 "OwenIt\\Auditing\\AuditingServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "analyse": "vendor/bin/phpstan analyse"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,56 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Result of static method OwenIt\\\\Auditing\\\\Facades\\\\Auditor\\:\\:execute\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: src/AuditableObserver.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\ApiModel\\:\\:auditAttach\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/ApiModel.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\ApiModel\\:\\:auditDetach\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/ApiModel.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\ApiModel\\:\\:auditSync\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/ApiModel.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\Article\\:\\:auditAttach\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/Article.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\Article\\:\\:auditDetach\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/Article.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\Article\\:\\:auditSync\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/Article.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\User\\:\\:auditAttach\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/User.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\User\\:\\:auditDetach\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/User.php
+
+		-
+			message: "#^Method OwenIt\\\\Auditing\\\\Tests\\\\Models\\\\User\\:\\:auditSync\\(\\) has OwenIt\\\\Auditing\\\\Exceptions\\\\AuditingException in PHPDoc @throws tag but it's not thrown\\.$#"
+			count: 1
+			path: tests/Models/User.php
+
+		-
+			message: "#^Called 'first' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: tests/Unit/AuditableTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,23 @@
+includes:
+    - ./phpstan-baseline.neon
+    - vendor/larastan/larastan/extension.neon
+    - vendor/phpstan/phpstan-mockery/extension.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+parameters:
+    level: 0
+    paths:
+        - ./config
+        - ./database
+        - ./src
+        - ./tests
+    exceptions:
+        implicitThrows: false
+        check:
+            tooWideThrowType: true
+    excludePaths:
+        - tests/database/migrations
+services:
+    -
+        class: PHPStan\Rules\Classes\RequireParentConstructCallRule
+        tags:
+            - phpstan.rules.rule


### PR DESCRIPTION
This can be merged to `v13` as it is only generates a baseline, without actual code change to ensure no more PHPStan level 0 issues are introduced, such as:
basic checks, unknown classes, unknown functions, unknown methods called on $this, wrong number of arguments passed to those methods and functions, always undefined variables