### PR TITLE
🐛 void function does not return

### DIFF
--- a/src/AuditableObserver.php
+++ b/src/AuditableObserver.php
@@ -107,7 +107,8 @@ class AuditableObserver
 
         $model->preloadResolverData();
         if (!Config::get('audit.queue.enable', false)) {
-            return Auditor::execute($model);
+            Auditor::execute($model);
+            return;
         }
 
         if (!$this->fireDispatchingAuditEvent($model)) {

--- a/src/Contracts/Auditor.php
+++ b/src/Contracts/Auditor.php
@@ -6,17 +6,11 @@ interface Auditor
 {
     /**
      * Get an audit driver instance.
-     *
-     * @param \OwenIt\Auditing\Contracts\Auditable $model
-     *
-     * @return AuditDriver
      */
     public function auditDriver(Auditable $model): AuditDriver;
 
     /**
      * Perform an audit.
-     *
-     * @param \OwenIt\Auditing\Contracts\Auditable $model
      *
      * @return void
      */


### PR DESCRIPTION
Returning from a void function caused a big error at one point during my tests, presumably not a problem currently but may well be soon.

Also cleaned up the contract but left the void as sort of optional in case someone out there is returning from it.