### PR TITLE
🐛 unserialize must be void

### DIFF
--- a/src/Events/DispatchAudit.php
+++ b/src/Events/DispatchAudit.php
@@ -56,7 +56,7 @@ class DispatchAudit
         foreach ($customProperties as $key) {
             try {
                 $values['model_data'][$key] = $this->getModelPropertyValue($reflection, $key);
-            } catch (\Throwable $e){
+            } catch (\Throwable $e) {
                 //
             }
         }
@@ -67,10 +67,9 @@ class DispatchAudit
     /**
      * Restore the model after serialization.
      *
-     * @param  array  $values
-     * @return array
+     * @param array<string,mixed> $values
      */
-    public function __unserialize(array $values)
+    public function __unserialize(array $values): void
     {
         $this->model = new $values['class'];
 
@@ -78,8 +77,6 @@ class DispatchAudit
         foreach ($values['model_data'] as $key => $value) {
             $this->setModelPropertyValue($reflection, $key, $value);
         }
-
-        return $values;
     }
 
     /**


### PR DESCRIPTION
When I tried to add the array types for phpstan, php linting pointed out this function must return void and not array. Also there was a missing space I spotted.

I'm presuming this return has just been unused all this time but I can't say I have used unserialize for a long time.