### PR TITLE
♻️ float no more

### DIFF
--- a/src/Redactors/LeftRedactor.php
+++ b/src/Redactors/LeftRedactor.php
@@ -10,7 +10,7 @@ class LeftRedactor implements \OwenIt\Auditing\Contracts\AttributeRedactor
     public static function redact($value): string
     {
         $total = strlen($value);
-        $tenth = ceil($total / 10);
+        $tenth = (int) ceil($total / 10);
 
         // Make sure single character strings get redacted
         $length = ($total > $tenth) ? ($total - $tenth) : 1;

--- a/src/Redactors/RightRedactor.php
+++ b/src/Redactors/RightRedactor.php
@@ -10,7 +10,7 @@ class RightRedactor implements \OwenIt\Auditing\Contracts\AttributeRedactor
     public static function redact($value): string
     {
         $total = strlen($value);
-        $tenth = ceil($total / 10);
+        $tenth = (int) ceil($total / 10);
 
         // Make sure single character strings get redacted
         $length = ($total > $tenth) ? ($total - $tenth) : 1;


### PR DESCRIPTION
phpstan was annoyed about using a float in the `substr`, past you had cast it to int at the end, I thought it was slightly less messy to cast the result of `ceil` as that is where the float is introduced for some reason known only to the developers of PHP.