### PR TITLE
Fix null return in UserAgentResolver

### DIFF
--- a/src/Resolvers/UserAgentResolver.php
+++ b/src/Resolvers/UserAgentResolver.php
@@ -10,6 +10,6 @@ class UserAgentResolver implements Resolver
 {
     public static function resolve(Auditable $auditable): string
     {
-        return $auditable->preloadedResolverData['user_agent'] ?? Request::header('User-Agent');
+        return $auditable->preloadedResolverData['user_agent'] ?? Request::header('User-Agent', '');
     }
 }


### PR DESCRIPTION
`Request::header` could possibly return null. Fix by adding default empty string return.