### PR TITLE
[v14] Phpstan fixes

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -183,7 +183,13 @@ trait Audit
         }
 
         if (preg_match('/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/', $value)) {
-            return Date::instance(Carbon::createFromFormat('Y-m-d H:i:s', $value, Date::now('UTC')->getTimezone()));
+            $date = Carbon::createFromFormat('Y-m-d H:i:s', $value, Date::now('UTC')->getTimezone());
+
+            if (! $date) {
+                return $value;
+            }
+
+            return Date::instance($date);
         }
 
         try {

--- a/src/Resolvers/UrlResolver.php
+++ b/src/Resolvers/UrlResolver.php
@@ -25,7 +25,7 @@ class UrlResolver implements Resolver
     public static function resolveCommandLine(): string
     {
         $command = Request::server('argv', null);
-        if (is_array($command)) {
+        if (is_array($command)) { // @phpstan-ignore function.impossibleType
             return implode(' ', $command);
         }
 

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -276,9 +276,7 @@ class AuditingTest extends AuditingTestCase
         ]);
 
         foreach (range(1, 20) as $count) {
-            if ($count === 11) {
-                sleep(1);
-            }
+            Carbon::setTestNow(now()->addSeconds($count));
 
             $article->update([
                 'title' => 'Title #'.$count,


### PR DESCRIPTION
https://github.com/owen-it/laravel-auditing/pull/933/files
In the old version (`->get()->slice($threshold)->pluck('id')`) Memory performance was failing, since with `get()` all the data was brought as eloquent models

Now (`->pluck($keyName)->all()`) `pluck/all` is done directly, which would only use an int array

`whereIn` was replaced by `whereIntegerInRaw`(avoid too many Placeholders issue)

The same solution works on older Laravel versions, if merged it would also be released in v13: https://github.com/owen-it/laravel-auditing/actions/runs/14862464393/job/41730649233


UPDATE: `whereIntegerInRaw` would cause problems when the key is a string, like UUID?