### PR TITLE
Typehint `created_at` and `updated_at` values for phpstan

### DIFF
--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $event
  * @property array<string,mixed> $new_values
  * @property array<string,mixed> $old_values
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property mixed $user
  * @property mixed $auditable.
  */


### PR DESCRIPTION
I've been working on implementing some functionality for managing audit history in Filament, and I noticed that PHPStan gives an error for `created_at` and `updated_at` being undefined properties.

This PR type-hints them alongside some of the other model properties to resolve this.