### PR TITLE
Add `auditable_type` and `auditable_id` properties to Audit Model

### DIFF
--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property Carbon|null $updated_at
  * @property mixed $user
  * @property mixed $auditable.
+ * @property string|null $auditable_type
+ * @property string|int|null $auditable_id
  */
 class Audit extends Model implements \OwenIt\Auditing\Contracts\Audit
 {

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -3,6 +3,7 @@
 namespace OwenIt\Auditing\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 /**
  * @property string $tags


### PR DESCRIPTION
EDIT: imported Carbon, apparently I missed that last time. Sorry 😬 

Hi, Another addition to the Audit docblock to help with PHPStan type hinting.

This one is to add the `auditable_type` and `auditable_id` columns used for the `auditable` relation so they can be selcted, plucked, etc. The reason for this is an example below:

```php
Audit::query()->distinct()->pluck('auditable_type');
```

In PHPStan levels 7 and above, this gives the following error:

```
 ------ ----------------------------------------------------------------------------- 
  Line   Filament/AuditResource.php                                                   
 ------ ----------------------------------------------------------------------------- 
  241    Parameter #1 $column of method                                               
         Illuminate\Database\Eloquent\Builder<OwenIt\Auditing\Models\Audit>::pluck()  
         expects Illuminate\Contracts\Database\Query\Expression|model property        
         of OwenIt\Auditing\Models\Audit, string given.                               
         🪪 argument.type                                                             
         💡 Type #2 from the union: The given string should be a property of          
            OwenIt\Auditing\Models\Audit, auditable_type given.                       
 ------ -----------------------------------------------------------------------------
```

Adding the properties to the Audit model resolves this. From looking at the migration stub, the morphable prefix for the auditable column cannot be changed so there shouldn't be a risk of these type hinted properties being incorrect.

#### User Properties

I haven't made the same change for the `user` relation. The reason why is that the config (and migration) allows for altering the prefix of the user morph column.

https://github.com/owen-it/laravel-auditing/blob/c57fbec4985aaeee53cb17d48f8c95317fca320b/config/audit.php#L27-L34

https://github.com/owen-it/laravel-auditing/blob/c57fbec4985aaeee53cb17d48f8c95317fca320b/database/migrations/audits.stub#L21-L24

Therefore, trying to type hint them would be unreliable, as they can be changed.
