### PR TITLE
make auditable on resolver be nullable

### DIFF
--- a/src/Contracts/Resolver.php
+++ b/src/Contracts/Resolver.php
@@ -5,5 +5,5 @@ namespace OwenIt\Auditing\Contracts;
 interface Resolver
 {
     /** @return mixed */
-    public static function resolve(Auditable $auditable);
+    public static function resolve(?Auditable $auditable = null);
 }

--- a/src/Resolvers/DumpResolver.php
+++ b/src/Resolvers/DumpResolver.php
@@ -7,7 +7,7 @@ use OwenIt\Auditing\Contracts\Resolver;
 
 class DumpResolver implements Resolver
 {
-    public static function resolve(Auditable $auditable): string
+    public static function resolve(?Auditable $auditable = null): string
     {
         return '';
     }

--- a/src/Resolvers/IpAddressResolver.php
+++ b/src/Resolvers/IpAddressResolver.php
@@ -8,8 +8,8 @@ use OwenIt\Auditing\Contracts\Resolver;
 
 class IpAddressResolver implements Resolver
 {
-    public static function resolve(Auditable $auditable): string
+    public static function resolve(?Auditable $auditable = null): string
     {
-        return $auditable->preloadedResolverData['ip_address'] ?? Request::ip();
+        return $auditable?->preloadedResolverData['ip_address'] ?? Request::ip();
     }
 }

--- a/src/Resolvers/UrlResolver.php
+++ b/src/Resolvers/UrlResolver.php
@@ -9,10 +9,10 @@ use OwenIt\Auditing\Contracts\Resolver;
 
 class UrlResolver implements Resolver
 {
-    public static function resolve(Auditable $auditable): string
+    public static function resolve(?Auditable $auditable = null): string
     {
-        if (! empty($auditable->preloadedResolverData['url'] ?? null)) {
-            return $auditable->preloadedResolverData['url'] ?? '';
+        if (! empty($auditable?->preloadedResolverData['url'] ?? null)) {
+            return $auditable?->preloadedResolverData['url'] ?? '';
         }
 
         if (App::runningInConsole()) {

--- a/src/Resolvers/UserAgentResolver.php
+++ b/src/Resolvers/UserAgentResolver.php
@@ -8,8 +8,8 @@ use OwenIt\Auditing\Contracts\Resolver;
 
 class UserAgentResolver implements Resolver
 {
-    public static function resolve(Auditable $auditable): string
+    public static function resolve(?Auditable $auditable = null): string
     {
-        return $auditable->preloadedResolverData['user_agent'] ?? Request::header('User-Agent', '');
+        return $auditable?->preloadedResolverData['user_agent'] ?? Request::header('User-Agent', '');
     }
 }

--- a/tests/fixtures/TenantResolver.php
+++ b/tests/fixtures/TenantResolver.php
@@ -7,7 +7,7 @@ use OwenIt\Auditing\Contracts\Resolver;
 
 class TenantResolver implements Resolver
 {
-    public static function resolve(Auditable $auditable)
+    public static function resolve(?Auditable $auditable = null)
     {
         return 1;
     }


### PR DESCRIPTION
### Details

By default the resolver contract requires that an Auditable be passed through, but for most of the time - there's a null coalesce used against the auditable's ->preloadedResolverData. By allowing these to be optional/nullable, this allows the default fallback to be used where you don't have an Auditable instantiated at this time.


#### Changes
- update contract to allow $auditable to be optional/nullable
- update all contract usages to match updated contract
- update all calls in resolvers to use the nullsafe operator (from php 8.0 ) to maintain existing functionality
  