### PR TITLE
Show deprecations on phpunit

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,8 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
         exclude:
+          - laravel: 11.*
+            php: 8.5
           - laravel: 13.*
             php: 8.2
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,12 @@
          stopOnFailure="true"
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false"
+         failOnDeprecation="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <testsuites>
         <testsuite name="Auditing Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,7 @@
          stopOnFailure="true"
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false"
-         failOnDeprecation="true"
+         failOnDeprecation="false"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerNotices="true"

--- a/tests/Functional/AuditingTest.php
+++ b/tests/Functional/AuditingTest.php
@@ -962,12 +962,8 @@ class AuditingTest extends AuditingTestCase
         $this->assertNotEmpty($audit);
         $this->assertSame(get_class($audit), \OwenIt\Auditing\Tests\Models\CustomAudit::class);
     }
-    
-    /**
-     * @test
-     * @return void
-     */
-    public function itWillAuditSyncWithAuditablePivotClass()
+
+    public function test_it_will_audit_sync_with_auditable_pivot_class()
     {
         $group = Group::factory()->create();
         $user = User::factory()->create();
@@ -987,12 +983,8 @@ class AuditingTest extends AuditingTestCase
         $this->assertGreaterThan($no_of_audits_before, $no_of_audits_mid);
         $this->assertGreaterThan($no_of_audits_mid, $no_of_audits_after);
     }
-    
-    /**
-     * @test
-     * @return void
-     */
-    public function itWillAuditAttachWithAuditablePivotClass()
+
+    public function test_it_will_audit_attach_with_auditable_pivot_class()
     {
         $group = Group::factory()->create();
         $user = User::factory()->create();
@@ -1007,12 +999,8 @@ class AuditingTest extends AuditingTestCase
         $this->assertSame($group->getKey(), $attachedGroup);
         $this->assertGreaterThan($no_of_audits_before, $no_of_audits_after);
     }
-    
-    /**
-     * @test
-     * @return void
-     */
-    public function itWillAuditDetachWithAuditablePivotClass()
+
+    public function test_it_will_audit_detach_with_auditable_pivot_class()
     {
         $group = Group::factory()->create();
         $user = User::factory()->create();


### PR DESCRIPTION
@willpower232 I thought about `failOnDeprecation`, but that would imply that the vendor's deprecation would also cause fails. Example: Laravel 11 with PHP 8.5 tests

But at least we can display deprecations messages to decide how to proceed

What do you think about it?