### PR TITLE
Add return type hints to Auditable and Auditor contracts

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -479,7 +479,7 @@ trait Auditable
     /**
      * {@inheritdoc}
      */
-    public function getAuditEvent()
+    public function getAuditEvent(): ?string
     {
         return $this->auditEvent;
     }
@@ -577,7 +577,7 @@ trait Auditable
     /**
      * {@inheritdoc}
      */
-    public function getAuditDriver()
+    public function getAuditDriver(): string
     {
         return $this->auditDriver ?? Config::get('audit.driver', 'database');
     }

--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -26,7 +26,7 @@ interface Auditable
      *
      * @return string|null
      */
-    public function getAuditEvent();
+    public function getAuditEvent(): ?string;
 
     /**
      * Get the events that trigger an Audit.
@@ -75,10 +75,8 @@ interface Auditable
 
     /**
      * Get the Audit Driver.
-     *
-     * @return string|null
      */
-    public function getAuditDriver();
+    public function getAuditDriver(): string;
 
     /**
      * Get the Audit threshold.

--- a/src/Contracts/Auditor.php
+++ b/src/Contracts/Auditor.php
@@ -14,5 +14,5 @@ interface Auditor
      *
      * @return void
      */
-    public function execute(Auditable $model);
+    public function execute(Auditable $model): void;
 }


### PR DESCRIPTION
## What this PR does

Adds native PHP return type hints to methods in `Auditable` and `Auditor` contracts that were either missing them or had incorrect PHPDoc annotations:

- `getAuditEvent(): ?string` — previously had no return type hint
- `getAuditDriver(): string` — previously had no return type hint and incorrect `@return string|null` PHPDoc (the method always returns a string via fallback)
- `execute(): void` — previously had no return type hint

## Why

Improves compatibility with static analysis tools (PHPStan, Psalm) and makes the API contracts more explicit without any breaking changes to existing behavior.
