### PR TITLE
Refactor audit creation to use savepoint

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -14,7 +14,7 @@ class Database implements AuditDriver
     public function audit(Auditable $model): ?Audit
     {
         return $model->withSavepointIfNeeded(
-            fn () => call_user_func([get_class($model->audits()->getModel()), 'create'], $model->toAudit())
+            fn () => $model->audits()->getModel()::create($model->toAudit())
         );
     }
 

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -13,7 +13,9 @@ class Database implements AuditDriver
      */
     public function audit(Auditable $model): ?Audit
     {
-        return call_user_func([get_class($model->audits()->getModel()), 'create'], $model->toAudit());
+        return $model->withSavepointIfNeeded(
+            fn () => call_user_func([get_class($model->audits()->getModel()), 'create'], $model->toAudit())
+        );
     }
 
     /**


### PR DESCRIPTION
Wraps the audits creation within a save point transaction using the withSavePointIfNeeded method

Postgres just needs it
For MySQL/SQLServer/SQLite, this is not necessary, but it shouldn't affect anything either.

- Closes #1043