### PR TITLE
Fix Async logging 

### DIFF
--- a/src/Listeners/ProcessDispatchAudit.php
+++ b/src/Listeners/ProcessDispatchAudit.php
@@ -26,10 +26,6 @@ class ProcessDispatchAudit implements ShouldQueue
 
     public function handle(DispatchAudit $event): void
     {
-        $modelClass = $event->model::class;
-        if (method_exists($modelClass, 'isAuditingEnabled') && ! $modelClass::isAuditingEnabled()) {
-            return;
-        }
         Auditor::execute($event->model);
     }
 }


### PR DESCRIPTION
- Closes #1058
- Bug from #1040

Remove check for auditing enabled before executing Auditor.
If the event has already been dispatched, it means that all audit requirements were met;
there is no need to check again.

Same as RecordCustomAudit :
https://github.com/owen-it/laravel-auditing/blob/4fb70d295a04a63ff2c00947a76c42aac1654741/src/Listeners/RecordCustomAudit.php#L8-L14

It works in sync, but we don't take into account async queues.

@willpower232 hi, any comments?