### PR TITLE
Typehint relations and `$user`/`$auditable` properties for phpstan

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -4,6 +4,7 @@ namespace OwenIt\Auditing;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
@@ -36,6 +37,8 @@ trait Audit
 
     /**
      * {@inheritdoc}
+     *
+     * @return MorphTo<Model, $this>
      */
     public function auditable()
     {
@@ -44,6 +47,8 @@ trait Audit
 
     /**
      * {@inheritdoc}
+     *
+     * @return MorphTo<Model, $this>
      */
     public function user()
     {

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -36,8 +36,6 @@ trait Audit
     protected $modified = [];
 
     /**
-     * {@inheritdoc}
-     *
      * @return MorphTo<Model, $this>
      */
     public function auditable()
@@ -46,8 +44,6 @@ trait Audit
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @return MorphTo<Model, $this>
      */
     public function user()

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -89,8 +89,6 @@ trait Auditable
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @return MorphMany<Models\Audit, $this>
      */
     public function audits(): MorphMany

--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -90,6 +90,8 @@ trait Auditable
 
     /**
      * {@inheritdoc}
+     *
+     * @return MorphMany<Models\Audit, $this>
      */
     public function audits(): MorphMany
     {

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -2,8 +2,10 @@
 
 namespace OwenIt\Auditing\Models;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
+use OwenIt\Auditing\Contracts\Auditable;
 
 /**
  * @property string $tags
@@ -12,8 +14,8 @@ use Illuminate\Support\Carbon;
  * @property array<string,mixed> $old_values
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property mixed $user
- * @property mixed $auditable.
+ * @property (Model&Authenticatable)|null $user
+ * @property (Model&Auditable)|null $auditable
  * @property string|null $auditable_type
  * @property string|int|null $auditable_id
  */


### PR DESCRIPTION
This adds the Eloquent relation generics (Laravel 11.15+) to the relation methods and types the `$user`/`$auditable` morph properties. **Docblocks and `use` statements only — there are no runtime behavior changes.**

Motivation: in our project we record custom audit events (`AuditCustom`) and add helpers through a project trait layered on top of `Auditable`. The relation methods and these properties are effectively untyped for static analysis, so each consumer ends up re-asserting types locally. Narrowing them on the library side makes consuming implementations safer.

- `Auditable::audits()`: `@return MorphMany<Models\Audit, $this>`
- `Audit::auditable()` / `Audit::user()`: `@return MorphTo<Model, $this>`
- `Models\Audit`: `@property (Model&Auditable)|null $auditable` and `@property (Model&Authenticatable)|null $user` — both were `mixed`, and the `$auditable` line had a stray trailing `.` that broke the annotation

Consumers running PHPStan/Larastan then get `$post->audits()` as `MorphMany<Audit, Post>`, `$post->audits` as `Collection<int, Audit>`, `$audit->user` as `(Model&Authenticatable)|null`, and so on.

PHPStan level 8 passes. The resolved types above were also verified with `PHPStan\dumpType()` against a sample consuming project (a local check, not part of this PR).
